### PR TITLE
Update to Pyo3 v0.22

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,11 +120,11 @@ futures = "0.3"
 inventory = { version = "0.3", optional = true }
 once_cell = "1.14"
 pin-project-lite = "0.2"
-pyo3 = "0.21"
+pyo3 = "0.22"
 pyo3-async-runtimes-macros = { path = "pyo3-asyncio-macros", version = "=0.21.0", optional = true }
 
 [dev-dependencies]
-pyo3 = { version = "0.21", features = ["macros"] }
+pyo3 = { version = "0.22", features = ["macros"] }
 
 [dependencies.async-std]
 version = "1.12"

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ fn rust_sleep(py: Python) -> PyResult<Bound<PyAny>> {
 }
 
 #[pymodule]
-fn my_async_module(py: Python, m: &PyModule) -> PyResult<()> {
+fn my_async_module(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(rust_sleep, m)?)?;
 
     Ok(())
@@ -183,7 +183,7 @@ fn rust_sleep(py: Python) -> PyResult<Bound<PyAny>> {
 }
 
 #[pymodule]
-fn my_async_module(py: Python, m: &PyModule) -> PyResult<()> {
+fn my_async_module(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(rust_sleep, m)?)?;
     Ok(())
 }
@@ -453,7 +453,7 @@ fn rust_sleep(py: Python) -> PyResult<Bound<PyAny>> {
 }
 
 #[pymodule]
-fn my_async_module(_py: Python, m: &PyModule) -> PyResult<()> {
+fn my_async_module(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(rust_sleep, m)?)?;
 
     Ok(())

--- a/pytests/test_async_std_asyncio.rs
+++ b/pytests/test_async_std_asyncio.rs
@@ -262,7 +262,7 @@ fn test_local_cancel(event_loop: PyObject) -> PyResult<()> {
 
 /// This module is implemented in Rust.
 #[pymodule]
-fn test_mod(_py: Python, m: &PyModule) -> PyResult<()> {
+fn test_mod(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     #![allow(deprecated)]
     #[pyfunction(name = "sleep")]
     fn sleep_(py: Python) -> PyResult<Bound<PyAny>> {
@@ -309,7 +309,7 @@ fn test_multiple_asyncio_run() -> PyResult<()> {
 }
 
 #[pymodule]
-fn cvars_mod(_py: Python, m: &PyModule) -> PyResult<()> {
+fn cvars_mod(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     #![allow(deprecated)]
     #[pyfunction]
     pub(crate) fn async_callback(py: Python, callback: PyObject) -> PyResult<Bound<PyAny>> {

--- a/pytests/tokio_asyncio/mod.rs
+++ b/pytests/tokio_asyncio/mod.rs
@@ -240,7 +240,7 @@ fn test_local_cancel(event_loop: PyObject) -> PyResult<()> {
 
 /// This module is implemented in Rust.
 #[pymodule]
-fn test_mod(_py: Python, m: &PyModule) -> PyResult<()> {
+fn test_mod(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     #![allow(deprecated)]
     #[pyfunction(name = "sleep")]
     fn sleep_(py: Python) -> PyResult<Bound<PyAny>> {
@@ -287,7 +287,7 @@ fn test_multiple_asyncio_run() -> PyResult<()> {
 }
 
 #[pymodule]
-fn cvars_mod(_py: Python, m: &PyModule) -> PyResult<()> {
+fn cvars_mod(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     #![allow(deprecated)]
     #[pyfunction]
     fn async_callback(py: Python, callback: PyObject) -> PyResult<Bound<PyAny>> {

--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -5,7 +5,7 @@
 //!   class="module-item stab portability"
 //!   style="display: inline; border-radius: 3px; padding: 2px; font-size: 80%; line-height: 1.2;"
 //! ><code>unstable-streams</code></span>
-//! are only available when the `unstable-streams` Cargo feature is enabled:
+//! >are only available when the `unstable-streams` Cargo feature is enabled:
 //!
 //! ```toml
 //! [dependencies.pyo3-asyncio-0-21]
@@ -71,7 +71,7 @@ impl Runtime for AsyncStdRuntime {
             AssertUnwindSafe(fut)
                 .catch_unwind()
                 .await
-                .map_err(|e| AsyncStdJoinErr(e))
+                .map_err(AsyncStdJoinErr)
         })
     }
 }
@@ -236,13 +236,13 @@ where
 /// via [`into_future`] (new behaviour in `v0.15`).
 ///
 /// > Although `contextvars` are preserved for async Python functions, synchronous functions will
-/// unfortunately fail to resolve them when called within the Rust future. This is because the
-/// function is being called from a Rust thread, not inside an actual Python coroutine context.
+/// > unfortunately fail to resolve them when called within the Rust future. This is because the
+/// > function is being called from a Rust thread, not inside an actual Python coroutine context.
 /// >
 /// > As a workaround, you can get the `contextvars` from the current task locals using
-/// [`get_current_locals`] and [`TaskLocals::context`](`crate::TaskLocals::context`), then wrap your
-/// synchronous function in a call to `contextvars.Context.run`. This will set the context, call the
-/// synchronous function, and restore the previous context when it returns or raises an exception.
+/// > [`get_current_locals`] and [`TaskLocals::context`](`crate::TaskLocals::context`), then wrap your
+/// > synchronous function in a call to `contextvars.Context.run`. This will set the context, call the
+/// > synchronous function, and restore the previous context when it returns or raises an exception.
 ///
 /// # Arguments
 /// * `py` - PyO3 GIL guard
@@ -291,13 +291,13 @@ where
 /// via [`into_future`] (new behaviour in `v0.15`).
 ///
 /// > Although `contextvars` are preserved for async Python functions, synchronous functions will
-/// unfortunately fail to resolve them when called within the Rust future. This is because the
-/// function is being called from a Rust thread, not inside an actual Python coroutine context.
+/// > unfortunately fail to resolve them when called within the Rust future. This is because the
+/// > function is being called from a Rust thread, not inside an actual Python coroutine context.
 /// >
 /// > As a workaround, you can get the `contextvars` from the current task locals using
-/// [`get_current_locals`] and [`TaskLocals::context`](`crate::TaskLocals::context`), then wrap your
-/// synchronous function in a call to `contextvars.Context.run`. This will set the context, call the
-/// synchronous function, and restore the previous context when it returns or raises an exception.
+/// > [`get_current_locals`] and [`TaskLocals::context`](`crate::TaskLocals::context`), then wrap your
+/// > synchronous function in a call to `contextvars.Context.run`. This will set the context, call the
+/// > synchronous function, and restore the previous context when it returns or raises an exception.
 ///
 /// # Arguments
 /// * `py` - The current PyO3 GIL guard
@@ -337,13 +337,13 @@ where
 /// via [`into_future`] (new behaviour in `v0.15`).
 ///
 /// > Although `contextvars` are preserved for async Python functions, synchronous functions will
-/// unfortunately fail to resolve them when called within the Rust future. This is because the
-/// function is being called from a Rust thread, not inside an actual Python coroutine context.
+/// > unfortunately fail to resolve them when called within the Rust future. This is because the
+/// > function is being called from a Rust thread, not inside an actual Python coroutine context.
 /// >
 /// > As a workaround, you can get the `contextvars` from the current task locals using
-/// [`get_current_locals`] and [`TaskLocals::context`](`crate::TaskLocals::context`), then wrap your
-/// synchronous function in a call to `contextvars.Context.run`. This will set the context, call the
-/// synchronous function, and restore the previous context when it returns or raises an exception.
+/// > [`get_current_locals`] and [`TaskLocals::context`](`crate::TaskLocals::context`), then wrap your
+/// > synchronous function in a call to `contextvars.Context.run`. This will set the context, call the
+/// > synchronous function, and restore the previous context when it returns or raises an exception.
 ///
 /// # Arguments
 /// * `py` - PyO3 GIL guard
@@ -412,13 +412,13 @@ where
 /// via [`into_future`] (new behaviour in `v0.15`).
 ///
 /// > Although `contextvars` are preserved for async Python functions, synchronous functions will
-/// unfortunately fail to resolve them when called within the Rust future. This is because the
-/// function is being called from a Rust thread, not inside an actual Python coroutine context.
+/// > unfortunately fail to resolve them when called within the Rust future. This is because the
+/// > function is being called from a Rust thread, not inside an actual Python coroutine context.
 /// >
 /// > As a workaround, you can get the `contextvars` from the current task locals using
-/// [`get_current_locals`] and [`TaskLocals::context`](`crate::TaskLocals::context`), then wrap your
-/// synchronous function in a call to `contextvars.Context.run`. This will set the context, call the
-/// synchronous function, and restore the previous context when it returns or raises an exception.
+/// > [`get_current_locals`] and [`TaskLocals::context`](`crate::TaskLocals::context`), then wrap your
+/// > synchronous function in a call to `contextvars.Context.run`. This will set the context, call the
+/// > synchronous function, and restore the previous context when it returns or raises an exception.
 ///
 /// # Arguments
 /// * `py` - The current PyO3 GIL guard
@@ -573,8 +573,8 @@ pub fn into_future(
 /// # fn main() {}
 /// ```
 #[cfg(feature = "unstable-streams")]
-pub fn into_stream_v1<'p>(
-    gen: Bound<'p, PyAny>,
+pub fn into_stream_v1(
+    gen: Bound<'_, PyAny>,
 ) -> PyResult<impl futures::Stream<Item = PyResult<PyObject>> + 'static> {
     generic::into_stream_v1::<AsyncStdRuntime>(gen)
 }
@@ -633,9 +633,9 @@ pub fn into_stream_v1<'p>(
 /// # fn main() {}
 /// ```
 #[cfg(feature = "unstable-streams")]
-pub fn into_stream_with_locals_v1<'p>(
+pub fn into_stream_with_locals_v1(
     locals: TaskLocals,
-    gen: Bound<'p, PyAny>,
+    gen: Bound<'_, PyAny>,
 ) -> PyResult<impl futures::Stream<Item = PyResult<PyObject>> + 'static> {
     generic::into_stream_with_locals_v1::<AsyncStdRuntime>(locals, gen)
 }
@@ -694,9 +694,9 @@ pub fn into_stream_with_locals_v1<'p>(
 /// # fn main() {}
 /// ```
 #[cfg(feature = "unstable-streams")]
-pub fn into_stream_with_locals_v2<'p>(
+pub fn into_stream_with_locals_v2(
     locals: TaskLocals,
-    gen: Bound<'p, PyAny>,
+    gen: Bound<'_, PyAny>,
 ) -> PyResult<impl futures::Stream<Item = PyObject> + 'static> {
     generic::into_stream_with_locals_v2::<AsyncStdRuntime>(locals, gen)
 }
@@ -751,8 +751,8 @@ pub fn into_stream_with_locals_v2<'p>(
 /// # fn main() {}
 /// ```
 #[cfg(feature = "unstable-streams")]
-pub fn into_stream_v2<'p>(
-    gen: Bound<'p, PyAny>,
+pub fn into_stream_v2(
+    gen: Bound<'_, PyAny>,
 ) -> PyResult<impl futures::Stream<Item = PyObject> + 'static> {
     generic::into_stream_v2::<AsyncStdRuntime>(gen)
 }

--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -5,7 +5,7 @@
 //!   class="module-item stab portability"
 //!   style="display: inline; border-radius: 3px; padding: 2px; font-size: 80%; line-height: 1.2;"
 //! ><code>unstable-streams</code></span>
-//! >are only available when the `unstable-streams` Cargo feature is enabled:
+//! are only available when the `unstable-streams` Cargo feature is enabled:
 //!
 //! ```toml
 //! [dependencies.pyo3-asyncio-0-21]

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -15,24 +15,24 @@
 
 use std::{
     future::Future,
-    marker::PhantomData,
     pin::Pin,
     sync::{Arc, Mutex},
     task::{Context, Poll},
 };
 
-use futures::{
-    channel::{mpsc, oneshot},
-    SinkExt,
-};
-use once_cell::sync::OnceCell;
-use pin_project_lite::pin_project;
-use pyo3::prelude::*;
-
 use crate::{
     asyncio, call_soon_threadsafe, close, create_future, dump_err, err::RustPanic,
     get_running_loop, into_future_with_locals, TaskLocals,
 };
+use futures::channel::oneshot;
+#[cfg(feature = "unstable-streams")]
+use futures::{channel::mpsc, SinkExt};
+#[cfg(feature = "unstable-streams")]
+use once_cell::sync::OnceCell;
+use pin_project_lite::pin_project;
+use pyo3::prelude::*;
+#[cfg(feature = "unstable-streams")]
+use std::marker::PhantomData;
 
 /// Generic utilities for a JoinError
 pub trait JoinError {
@@ -585,7 +585,7 @@ where
 {
     let (cancel_tx, cancel_rx) = oneshot::channel();
 
-    let py_fut = create_future(locals.event_loop.clone().into_bound(py))?;
+    let py_fut = create_future(locals.event_loop.bind(py).clone())?;
     py_fut.call_method1(
         "add_done_callback",
         (PyDoneCallback {
@@ -594,14 +594,14 @@ where
     )?;
 
     let future_tx1 = PyObject::from(py_fut.clone());
-    let future_tx2 = future_tx1.clone();
+    let future_tx2 = future_tx1.clone_ref(py);
 
     R::spawn(async move {
-        let locals2 = locals.clone();
+        let locals2 = Python::with_gil(|py| locals.clone_ref(py));
 
         if let Err(e) = R::spawn(async move {
             let result = R::scope(
-                locals2.clone(),
+                Python::with_gil(|py| locals2.clone_ref(py)),
                 Cancellable::new_with_cancel_rx(fut, cancel_rx),
             )
             .await;
@@ -990,7 +990,7 @@ where
 {
     let (cancel_tx, cancel_rx) = oneshot::channel();
 
-    let py_fut = create_future(locals.event_loop.clone().into_bound(py))?;
+    let py_fut = create_future(locals.event_loop.clone_ref(py).into_bound(py))?;
     py_fut.call_method1(
         "add_done_callback",
         (PyDoneCallback {
@@ -999,14 +999,14 @@ where
     )?;
 
     let future_tx1 = PyObject::from(py_fut.clone());
-    let future_tx2 = future_tx1.clone();
+    let future_tx2 = future_tx1.clone_ref(py);
 
     R::spawn_local(async move {
-        let locals2 = locals.clone();
+        let locals2 = Python::with_gil(|py| locals.clone_ref(py));
 
         if let Err(e) = R::spawn_local(async move {
             let result = R::scope_local(
-                locals2.clone(),
+                Python::with_gil(|py| locals2.clone_ref(py)),
                 Cancellable::new_with_cancel_rx(fut, cancel_rx),
             )
             .await;
@@ -1446,27 +1446,12 @@ where
     into_stream_with_locals_v1::<R>(get_current_locals::<R>(gen.py())?, gen)
 }
 
-#[allow(dead_code)]
-fn py_true() -> PyObject {
-    static TRUE: OnceCell<PyObject> = OnceCell::new();
-    TRUE.get_or_init(|| Python::with_gil(|py| true.into_py(py)))
-        .clone()
-}
-
-#[allow(dead_code)]
-fn py_false() -> PyObject {
-    static FALSE: OnceCell<PyObject> = OnceCell::new();
-    FALSE
-        .get_or_init(|| Python::with_gil(|py| false.into_py(py)))
-        .clone()
-}
-
 trait Sender: Send + 'static {
-    fn send(&mut self, locals: TaskLocals, item: PyObject) -> PyResult<PyObject>;
+    fn send(&mut self, py: Python, locals: TaskLocals, item: PyObject) -> PyResult<PyObject>;
     fn close(&mut self) -> PyResult<()>;
 }
 
-#[allow(dead_code)]
+#[cfg(feature = "unstable-streams")]
 struct GenericSender<R>
 where
     R: Runtime,
@@ -1475,13 +1460,14 @@ where
     tx: mpsc::Sender<PyObject>,
 }
 
+#[cfg(feature = "unstable-streams")]
 impl<R> Sender for GenericSender<R>
 where
     R: Runtime + ContextExt,
 {
-    fn send(&mut self, locals: TaskLocals, item: PyObject) -> PyResult<PyObject> {
-        match self.tx.try_send(item.clone()) {
-            Ok(_) => Ok(py_true()),
+    fn send(&mut self, py: Python, locals: TaskLocals, item: PyObject) -> PyResult<PyObject> {
+        match self.tx.try_send(item.clone_ref(py)) {
+            Ok(_) => Ok(true.into_py(py)),
             Err(e) => {
                 if e.is_full() {
                     let mut tx = self.tx.clone();
@@ -1490,19 +1476,19 @@ where
                             future_into_py_with_locals::<R, _, PyObject>(py, locals, async move {
                                 if tx.flush().await.is_err() {
                                     // receiving side disconnected
-                                    return Ok(py_false());
+                                    return Python::with_gil(|py| Ok(false.into_py(py)));
                                 }
                                 if tx.send(item).await.is_err() {
                                     // receiving side disconnected
-                                    return Ok(py_false());
+                                    return Python::with_gil(|py| Ok(false.into_py(py)));
                                 }
-                                Ok(py_true())
+                                Python::with_gil(|py| Ok(true.into_py(py)))
                             })?
                             .into(),
                         )
                     })
                 } else {
-                    Ok(py_false())
+                    Ok(false.into_py(py))
                 }
             }
         }
@@ -1521,7 +1507,7 @@ struct SenderGlue {
 #[pymethods]
 impl SenderGlue {
     pub fn send(&mut self, item: PyObject) -> PyResult<PyObject> {
-        self.tx.send(self.locals.clone(), item)
+        Python::with_gil(|py| self.tx.send(py, self.locals.clone_ref(py), item))
     }
     pub fn close(&mut self) -> PyResult<()> {
         self.tx.close()

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -1293,9 +1293,9 @@ where
 /// ```
 #[cfg(feature = "unstable-streams")]
 #[allow(unused_must_use)] // False positive unused lint on `R::spawn`
-pub fn into_stream_with_locals_v1<'p, R>(
+pub fn into_stream_with_locals_v1<R>(
     locals: TaskLocals,
-    gen: Bound<'p, PyAny>,
+    gen: Bound<'_, PyAny>,
 ) -> PyResult<impl futures::Stream<Item = PyResult<PyObject>> + 'static>
 where
     R: Runtime,
@@ -1437,8 +1437,8 @@ where
 /// # }
 /// ```
 #[cfg(feature = "unstable-streams")]
-pub fn into_stream_v1<'p, R>(
-    gen: Bound<'p, PyAny>,
+pub fn into_stream_v1<R>(
+    gen: Bound<'_, PyAny>,
 ) -> PyResult<impl futures::Stream<Item = PyResult<PyObject>> + 'static>
 where
     R: Runtime + ContextExt,
@@ -1651,9 +1651,9 @@ async def forward(gen, sender):
 /// # }
 /// ```
 #[cfg(feature = "unstable-streams")]
-pub fn into_stream_with_locals_v2<'p, R>(
+pub fn into_stream_with_locals_v2<R>(
     locals: TaskLocals,
-    gen: Bound<'p, PyAny>,
+    gen: Bound<'_, PyAny>,
 ) -> PyResult<impl futures::Stream<Item = PyObject> + 'static>
 where
     R: Runtime + ContextExt,
@@ -1796,8 +1796,8 @@ where
 /// # }
 /// ```
 #[cfg(feature = "unstable-streams")]
-pub fn into_stream_v2<'p, R>(
-    gen: Bound<'p, PyAny>,
+pub fn into_stream_v2<R>(
+    gen: Bound<'_, PyAny>,
 ) -> PyResult<impl futures::Stream<Item = PyObject> + 'static>
 where
     R: Runtime + ContextExt,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -473,7 +473,7 @@ fn copy_context(py: Python) -> PyResult<Bound<PyAny>> {
 }
 
 /// Task-local data to store for Python conversions.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct TaskLocals {
     /// Track the event loop of the Python task
     event_loop: PyObject,
@@ -510,12 +510,21 @@ impl TaskLocals {
 
     /// Get a reference to the event loop
     pub fn event_loop<'p>(&self, py: Python<'p>) -> Bound<'p, PyAny> {
-        self.event_loop.clone().into_bound(py)
+        self.event_loop.clone_ref(py).into_bound(py)
     }
 
     /// Get a reference to the python context
     pub fn context<'p>(&self, py: Python<'p>) -> Bound<'p, PyAny> {
-        self.context.clone().into_bound(py)
+        self.context.clone_ref(py).into_bound(py)
+    }
+
+    /// Create a clone of the TaskLocals by incrementing the reference counters of the event loop and
+    /// contextvars.
+    pub fn clone_ref(&self, py: Python<'_>) -> Self {
+        Self {
+            event_loop: self.event_loop.clone_ref(py),
+            context: self.context.clone_ref(py),
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@
 //!     let locals = pyo3_async_runtimes::TaskLocals::with_running_loop(py)?.copy_context(py)?;
 //!
 //!     // Convert the async move { } block to a Python awaitable
-//!     pyo3_async_runtimes::tokio::future_into_py_with_locals(py, locals.clone(), async move {
+//!     pyo3_async_runtimes::tokio::future_into_py_with_locals(py, locals.clone_ref(py), async move {
 //!         let py_sleep = Python::with_gil(|py| {
 //!             // Sometimes we need to call other async Python functions within
 //!             // this future. In order for this to work, we need to track the
@@ -112,7 +112,7 @@
 //!
 //! # #[cfg(feature = "tokio-runtime")]
 //! #[pymodule]
-//! fn my_mod(py: Python, m: &PyModule) -> PyResult<()> {
+//! fn my_mod(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
 //!     m.add_function(wrap_pyfunction!(sleep, m)?)?;
 //!     Ok(())
 //! }
@@ -162,9 +162,9 @@
 //!
 //!     pyo3_async_runtimes::tokio::future_into_py_with_locals(
 //!         py,
-//!         locals.clone(),
+//!         locals.clone_ref(py),
 //!         // Store the current locals in task-local data
-//!         pyo3_async_runtimes::tokio::scope(locals.clone(), async move {
+//!         pyo3_async_runtimes::tokio::scope(locals.clone_ref(py), async move {
 //!             let py_sleep = Python::with_gil(|py| {
 //!                 pyo3_async_runtimes::into_future_with_locals(
 //!                     // Now we can get the current locals through task-local data
@@ -189,9 +189,9 @@
 //!
 //!     pyo3_async_runtimes::tokio::future_into_py_with_locals(
 //!         py,
-//!         locals.clone(),
+//!         locals.clone_ref(py),
 //!         // Store the current locals in task-local data
-//!         pyo3_async_runtimes::tokio::scope(locals.clone(), async move {
+//!         pyo3_async_runtimes::tokio::scope(locals.clone_ref(py), async move {
 //!             let py_sleep = Python::with_gil(|py| {
 //!                 pyo3_async_runtimes::into_future_with_locals(
 //!                     &pyo3_async_runtimes::tokio::get_current_locals(py)?,
@@ -210,7 +210,7 @@
 //!
 //! # #[cfg(feature = "tokio-runtime")]
 //! #[pymodule]
-//! fn my_mod(py: Python, m: &PyModule) -> PyResult<()> {
+//! fn my_mod(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
 //!     m.add_function(wrap_pyfunction!(sleep, m)?)?;
 //!     m.add_function(wrap_pyfunction!(wrap_sleep, m)?)?;
 //!     Ok(())
@@ -270,7 +270,7 @@
 //!
 //! # #[cfg(feature = "tokio-runtime")]
 //! #[pymodule]
-//! fn my_mod(py: Python, m: &PyModule) -> PyResult<()> {
+//! fn my_mod(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
 //!     m.add_function(wrap_pyfunction!(sleep, m)?)?;
 //!     m.add_function(wrap_pyfunction!(wrap_sleep, m)?)?;
 //!     Ok(())

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -189,14 +189,9 @@ use pyo3::prelude::*;
 ///
 /// These args are meant to mirror the default test harness's args.
 /// > Currently only `--filter` is supported.
+#[derive(Default)]
 pub struct Args {
     filter: Option<String>,
-}
-
-impl Default for Args {
-    fn default() -> Self {
-        Self { filter: None }
-    }
 }
 
 /// Parse the test args from the command line
@@ -240,9 +235,7 @@ pub fn parse_args() -> Args {
         .get_matches();
 
     Args {
-        filter: matches
-            .get_one::<String>("TESTNAME")
-            .map(|name| name.clone()),
+        filter: matches.get_one::<String>("TESTNAME").cloned(),
     }
 }
 
@@ -315,11 +308,7 @@ pub async fn test_harness(tests: Vec<Test>, args: Args) -> PyResult<()> {
 pub async fn main() -> PyResult<()> {
     let args = parse_args();
 
-    test_harness(
-        inventory::iter::<Test>().map(|test| test.clone()).collect(),
-        args,
-    )
-    .await
+    test_harness(inventory::iter::<Test>().cloned().collect(), args).await
 }
 
 #[cfg(test)]

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -5,7 +5,7 @@
 //!   class="module-item stab portability"
 //!   style="display: inline; border-radius: 3px; padding: 2px; font-size: 80%; line-height: 1.2;"
 //! ><code>unstable-streams</code></span>
-//! are only available when the `unstable-streams` Cargo feature is enabled:
+//! >are only available when the `unstable-streams` Cargo feature is enabled:
 //!
 //! ```toml
 //! [dependencies.pyo3-asyncio-0-21]
@@ -176,6 +176,7 @@ pub fn init(builder: Builder) {
 /// Initialize the Tokio runtime with a custom Tokio runtime
 ///
 /// Returns Ok(()) if success and Err(()) if it had been inited.
+#[allow(clippy::result_unit_err)]
 pub fn init_with_runtime(runtime: &'static Runtime) -> Result<(), ()> {
     TOKIO_RUNTIME
         .set(Pyo3Runtime::Borrowed(runtime))
@@ -278,13 +279,13 @@ where
 /// via [`into_future`] (new behaviour in `v0.15`).
 ///
 /// > Although `contextvars` are preserved for async Python functions, synchronous functions will
-/// unfortunately fail to resolve them when called within the Rust future. This is because the
-/// function is being called from a Rust thread, not inside an actual Python coroutine context.
+/// > unfortunately fail to resolve them when called within the Rust future. This is because the
+/// > function is being called from a Rust thread, not inside an actual Python coroutine context.
 /// >
 /// > As a workaround, you can get the `contextvars` from the current task locals using
-/// [`get_current_locals`] and [`TaskLocals::context`](`crate::TaskLocals::context`), then wrap your
-/// synchronous function in a call to `contextvars.Context.run`. This will set the context, call the
-/// synchronous function, and restore the previous context when it returns or raises an exception.
+/// > [`get_current_locals`] and [`TaskLocals::context`](`crate::TaskLocals::context`), then wrap your
+/// > synchronous function in a call to `contextvars.Context.run`. This will set the context, call the
+/// > synchronous function, and restore the previous context when it returns or raises an exception.
 ///
 /// # Arguments
 /// * `py` - PyO3 GIL guard
@@ -333,13 +334,13 @@ where
 /// via [`into_future`] (new behaviour in `v0.15`).
 ///
 /// > Although `contextvars` are preserved for async Python functions, synchronous functions will
-/// unfortunately fail to resolve them when called within the Rust future. This is because the
-/// function is being called from a Rust thread, not inside an actual Python coroutine context.
+/// > unfortunately fail to resolve them when called within the Rust future. This is because the
+/// > function is being called from a Rust thread, not inside an actual Python coroutine context.
 /// >
 /// > As a workaround, you can get the `contextvars` from the current task locals using
-/// [`get_current_locals`] and [`TaskLocals::context`](`crate::TaskLocals::context`), then wrap your
-/// synchronous function in a call to `contextvars.Context.run`. This will set the context, call the
-/// synchronous function, and restore the previous context when it returns or raises an exception.
+/// > [`get_current_locals`] and [`TaskLocals::context`](`crate::TaskLocals::context`), then wrap your
+/// > synchronous function in a call to `contextvars.Context.run`. This will set the context, call the
+/// > synchronous function, and restore the previous context when it returns or raises an exception.
 ///
 /// # Arguments
 /// * `py` - The current PyO3 GIL guard
@@ -379,13 +380,13 @@ where
 /// via [`into_future`] (new behaviour in `v0.15`).
 ///
 /// > Although `contextvars` are preserved for async Python functions, synchronous functions will
-/// unfortunately fail to resolve them when called within the Rust future. This is because the
-/// function is being called from a Rust thread, not inside an actual Python coroutine context.
+/// > unfortunately fail to resolve them when called within the Rust future. This is because the
+/// > function is being called from a Rust thread, not inside an actual Python coroutine context.
 /// >
 /// > As a workaround, you can get the `contextvars` from the current task locals using
-/// [`get_current_locals`] and [`TaskLocals::context`](`crate::TaskLocals::context`), then wrap your
-/// synchronous function in a call to `contextvars.Context.run`. This will set the context, call the
-/// synchronous function, and restore the previous context when it returns or raises an exception.
+/// > [`get_current_locals`] and [`TaskLocals::context`](`crate::TaskLocals::context`), then wrap your
+/// > synchronous function in a call to `contextvars.Context.run`. This will set the context, call the
+/// > synchronous function, and restore the previous context when it returns or raises an exception.
 ///
 /// # Arguments
 /// * `py` - PyO3 GIL guard
@@ -470,13 +471,13 @@ where
 /// via [`into_future`] (new behaviour in `v0.15`).
 ///
 /// > Although `contextvars` are preserved for async Python functions, synchronous functions will
-/// unfortunately fail to resolve them when called within the Rust future. This is because the
-/// function is being called from a Rust thread, not inside an actual Python coroutine context.
+/// > unfortunately fail to resolve them when called within the Rust future. This is because the
+/// > function is being called from a Rust thread, not inside an actual Python coroutine context.
 /// >
 /// > As a workaround, you can get the `contextvars` from the current task locals using
-/// [`get_current_locals`] and [`TaskLocals::context`](`crate::TaskLocals::context`), then wrap your
-/// synchronous function in a call to `contextvars.Context.run`. This will set the context, call the
-/// synchronous function, and restore the previous context when it returns or raises an exception.
+/// > [`get_current_locals`] and [`TaskLocals::context`](`crate::TaskLocals::context`), then wrap your
+/// > synchronous function in a call to `contextvars.Context.run`. This will set the context, call the
+/// > synchronous function, and restore the previous context when it returns or raises an exception.
 ///
 /// # Arguments
 /// * `py` - The current PyO3 GIL guard
@@ -650,9 +651,9 @@ pub fn into_future(
 /// # fn main() {}
 /// ```
 #[cfg(feature = "unstable-streams")]
-pub fn into_stream_with_locals_v1<'p>(
+pub fn into_stream_with_locals_v1(
     locals: TaskLocals,
-    gen: Bound<'p, PyAny>,
+    gen: Bound<'_, PyAny>,
 ) -> PyResult<impl futures::Stream<Item = PyResult<PyObject>> + 'static> {
     generic::into_stream_with_locals_v1::<TokioRuntime>(locals, gen)
 }
@@ -707,8 +708,8 @@ pub fn into_stream_with_locals_v1<'p>(
 /// # fn main() {}
 /// ```
 #[cfg(feature = "unstable-streams")]
-pub fn into_stream_v1<'p>(
-    gen: Bound<'p, PyAny>,
+pub fn into_stream_v1(
+    gen: Bound<'_, PyAny>,
 ) -> PyResult<impl futures::Stream<Item = PyResult<PyObject>> + 'static> {
     generic::into_stream_v1::<TokioRuntime>(gen)
 }
@@ -767,9 +768,9 @@ pub fn into_stream_v1<'p>(
 /// # fn main() {}
 /// ```
 #[cfg(feature = "unstable-streams")]
-pub fn into_stream_with_locals_v2<'p>(
+pub fn into_stream_with_locals_v2(
     locals: TaskLocals,
-    gen: Bound<'p, PyAny>,
+    gen: Bound<'_, PyAny>,
 ) -> PyResult<impl futures::Stream<Item = PyObject> + 'static> {
     generic::into_stream_with_locals_v2::<TokioRuntime>(locals, gen)
 }
@@ -824,8 +825,8 @@ pub fn into_stream_with_locals_v2<'p>(
 /// # fn main() {}
 /// ```
 #[cfg(feature = "unstable-streams")]
-pub fn into_stream_v2<'p>(
-    gen: Bound<'p, PyAny>,
+pub fn into_stream_v2(
+    gen: Bound<'_, PyAny>,
 ) -> PyResult<impl futures::Stream<Item = PyObject> + 'static> {
     generic::into_stream_v2::<TokioRuntime>(gen)
 }

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -109,10 +109,12 @@ impl ContextExt for TokioRuntime {
     }
 
     fn get_task_locals() -> Option<TaskLocals> {
-        match TASK_LOCALS.try_with(|c| c.get().map(|locals| locals.clone())) {
-            Ok(locals) => locals,
-            Err(_) => None,
-        }
+        TASK_LOCALS
+            .try_with(|c| {
+                c.get()
+                    .map(|locals| Python::with_gil(|py| locals.clone_ref(py)))
+            })
+            .unwrap_or_default()
     }
 }
 


### PR DESCRIPTION
This is my first attempt at updating to pyo3 v0.22 without the `py-clone` feature. I've added a `Python::with_gil` naively everywhere a GIL token was required, so it may need some refactoring & cleanup next. Furthermore all fmt/cargo checks should be resolved.

ref #1 