### PR TITLE
chore: Version bumps and package naming in CI and README

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -9,7 +9,7 @@ When reporting a bug, please provide the following information. If this is not a
  - How did you install python (e.g. apt or pyenv)? Did you use a virtualenv?:
  - Your Rust version (`rustc --version`):
  - Your PyO3 version:
- - Have you tried using latest PyO3 master (replace `version = "0.x.y"` with `git = "https://github.com/awestlake87/pyo3-asyncio")?`:
+ - Have you tried using latest PyO3 master (replace `version = "0.x.y"` with `git = "https://github.com/PyO3/pyo3-async-runtimes")?`:
 
 ### 💥 Reproducing
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-Thank you for contributing to pyo3-asyncio!
+Thank you for contributing to pyo3-async-runtimes!
 
 Please consider adding the following to your pull request:
  - an entry in CHANGELOG.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.10"
-      - run: pip install black==22.8.0
+      - run: pip install black==24.10.0
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
@@ -49,13 +49,10 @@ jobs:
         rust: [stable]
         python-version:
           [
-            "3.7",
-            "3.8",
             "3.9",
             "3.10",
-            "3.11-dev",
-            "pypy-3.7",
-            "pypy-3.8",
+            "3.11",
+            "3.12",
             "pypy-3.9",
           ]
         platform:
@@ -83,10 +80,6 @@ jobs:
           ]
         exclude:
           # PyPy doesn't release 32-bit Windows builds any more
-          - python-version: pypy-3.7
-            platform: { os: "windows-latest", python-architecture: "x86" }
-          - python-version: pypy-3.8
-            platform: { os: "windows-latest", python-architecture: "x86" }
           - python-version: pypy-3.9
             platform: { os: "windows-latest", python-architecture: "x86" }
         include:
@@ -103,7 +96,7 @@ jobs:
 
           # Test the `nightly` feature
           - rust: nightly
-            python-version: "3.10"
+            python-version: "3.12"
             platform:
               {
                 os: "ubuntu-latest",

--- a/.github/workflows/guide.yml
+++ b/.github/workflows/guide.yml
@@ -24,7 +24,7 @@ jobs:
           cargo doc --no-deps --all-features
           mkdir -p gh-pages-build
           cp -r target/doc gh-pages-build/doc
-          echo "<meta http-equiv=refresh content=0;url=pyo3_asyncio/index.html>" > gh-pages-build/doc/index.html
+          echo "<meta http-equiv=refresh content=0;url=pyo3_async_runtimes/index.html>" > gh-pages-build/doc/index.html
 
       - name: Prepare tag
         id: prepare_tag

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # PyO3 Asyncio
 
-[![Actions Status](https://github.com/davidhewitt/pyo3-asyncio/workflows/CI/badge.svg)](https://github.com/davidhewitt/pyo3-asyncio/actions)
-[![codecov](https://codecov.io/gh/davidhewitt/pyo3-asyncio/branch/master/graph/badge.svg)](https://codecov.io/gh/davidhewitt/pyo3-asyncio)
-[![crates.io](https://img.shields.io/crates/v/pyo3-asyncio-0-21)](https://crates.io/crates/pyo3-asyncio-0-21)
+[![Actions Status](https://github.com/PyO3/pyo3-async-runtimes/workflows/CI/badge.svg)](https://github.com/PyO3/pyo3-async-runtimes)
+[![codecov](https://codecov.io/gh/davidhewitt/pyo3-async-runtimes/branch/main/graph/badge.svg)](https://codecov.io/gh/PyO3/pyo3-async-runtimes)
+[![crates.io](https://img.shields.io/crates/v/pyo3-async-runtimes)](https://crates.io/crates/pyo3-async-runtimes)
 [![minimum rustc 1.63](https://img.shields.io/badge/rustc-1.63+-blue.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
 
 ***This is a fork of [`pyo3-asyncio`](https://github.com/awestlake87/pyo3-asyncio/) to deliver compatibility for PyO3 0.21. This may be the base for a permanent fork in the future, depending on the status of the original `pyo3-asyncio` maintainer.***
@@ -11,11 +11,11 @@
 
 - PyO3 Project: [Homepage](https://pyo3.rs/) | [GitHub](https://github.com/PyO3/pyo3)
 
-- PyO3 Asyncio API Documentation: [stable](https://docs.rs/pyo3-asyncio/) | [master](https://awestlake87.github.io/pyo3-asyncio/master/doc)
+- PyO3 Async Runtimes API Documentation: [stable](https://docs.rs/pyo3-async-runtimes/)
 
 - Guide for Async / Await [stable](https://pyo3.rs/latest/ecosystem/async-await.html) | [main](https://pyo3.rs/main/ecosystem/async-await.html)
 
-- Contributing Notes: [github](https://github.com/davidhewitt/pyo3-asyncio/blob/master/Contributing.md)
+- Contributing Notes: [github](https://github.com/PyO3/pyo3-async-runtimes/blob/main/Contributing.md)
 
 > PyO3 Asyncio is a _brand new_ part of the broader PyO3 ecosystem. Feel free to open any issues for feature requests or bugfixes for this crate.
 
@@ -31,7 +31,7 @@ Like PyO3, PyO3 Asyncio supports the following software versions:
 ## PyO3 Asyncio Primer
 
 If you are working with a Python library that makes use of async functions or wish to provide
-Python bindings for an async Rust library, [`pyo3-asyncio`](https://github.com/davidhewitt/pyo3-asyncio)
+Python bindings for an async Rust library, [`pyo3-async-runtimes`](https://github.com/PyO3/pyo3-async-runtimes)
 likely has the tools you need. It provides conversions between async functions in both Python and
 Rust and was designed with first-class support for popular Rust runtimes such as
 [`tokio`](https://tokio.rs/) and [`async-std`](https://async.rs/). In addition, all async Python
@@ -108,7 +108,8 @@ async fn main() -> PyResult<()> {
 }
 ```
 
-More details on the usage of this library can be found in the [API docs](https://awestlake87.github.io/pyo3-asyncio/master/doc) and the primer below.
+More details on the usage of this library can be found in the API docs
+and the primer below.
 
 #### PyO3 Native Rust Modules
 
@@ -423,7 +424,7 @@ Python allows you to use alternatives to the default `asyncio` event loop. One
 popular alternative is `uvloop`. In `v0.13` using non-standard event loops was
 a bit of an ordeal, but in `v0.14` it's trivial.
 
-#### Using `uvloop` in a PyO3 Asyncio Native Extensions
+#### Using `uvloop` in a PyO3 Native Extensions
 
 ```toml
 # Cargo.toml
@@ -534,7 +535,7 @@ fn main() -> PyResult<()> {
 
 ### Additional Information
 
-- Managing event loop references can be tricky with pyo3-asyncio. See [Event Loop References and ContextVars](https://awestlake87.github.io/pyo3-asyncio/master/doc/pyo3_async_runtimes/#event-loop-references-and-contextvars) in the API docs to get a better intuition for how event loop references are managed in this library.
+- Managing event loop references can be tricky with pyo3-async-runtimes. See [Event Loop References and ContextVars](https://awestlake87.github.io/pyo3-asyncio/master/doc/pyo3_async_runtimes/#event-loop-references-and-contextvars) in the API docs to get a better intuition for how event loop references are managed in this library.
 - Testing pyo3-asyncio libraries and applications requires a custom test harness since Python requires control over the main thread. You can find a testing guide in the [API docs for the `testing` module](https://awestlake87.github.io/pyo3-asyncio/master/doc/pyo3_async_runtimes/testing)
 
 ## Migration Guide

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ to do something special with the object that it returns.
 Normally in Python, that something special is the `await` keyword, but in order to await this
 coroutine in Rust, we first need to convert it into Rust's version of a `coroutine`: a `Future`.
 That's where `pyo3-async-runtimes` comes in.
-[`pyo3_async_runtimes::into_future`](https://docs.rs/pyo3-asyncio/latest/pyo3_asyncio/fn.into_future.html)
+[`pyo3_async_runtimes::into_future`](https://docs.rs/pyo3-asyncio/latest/pyo3_async_runtimes/fn.into_future.html)
 performs this conversion for us:
 
 ```rust no_run
@@ -281,7 +281,7 @@ let future = rust_sleep();
 
 We can convert this `Future` object into Python to make it `awaitable`. This tells Python that you
 can use the `await` keyword with it. In order to do this, we'll call
-[`pyo3_async_runtimes::async_std::future_into_py`](https://docs.rs/pyo3-asyncio/latest/pyo3_asyncio/async_std/fn.future_into_py.html):
+[`pyo3_async_runtimes::async_std::future_into_py`](https://docs.rs/pyo3-asyncio/latest/pyo3_async_runtimes/async_std/fn.future_into_py.html):
 
 ```rust
 use pyo3::prelude::*;
@@ -323,7 +323,7 @@ implementations _prefer_ control over the main thread, this can still make some 
 
 Because Python needs to control the main thread, we can't use the convenient proc macros from Rust
 runtimes to handle the `main` function or `#[test]` functions. Instead, the initialization for PyO3 has to be done from the `main` function and the main
-thread must block on [`pyo3_async_runtimes::run_forever`](https://docs.rs/pyo3-asyncio/latest/pyo3_asyncio/fn.run_forever.html) or [`pyo3_async_runtimes::async_std::run_until_complete`](https://docs.rs/pyo3-asyncio/latest/pyo3_asyncio/async_std/fn.run_until_complete.html).
+thread must block on [`pyo3_async_runtimes::run_forever`](https://docs.rs/pyo3-asyncio/latest/pyo3_async_runtimes/fn.run_forever.html) or [`pyo3_async_runtimes::async_std::run_until_complete`](https://docs.rs/pyo3-asyncio/latest/pyo3_async_runtimes/async_std/fn.run_until_complete.html).
 
 Because we have to block on one of those functions, we can't use [`#[async_std::main]`](https://docs.rs/async-std/latest/async_std/attr.main.html) or [`#[tokio::main]`](https://docs.rs/tokio/1.1.0/tokio/attr.main.html)
 since it's not a good idea to make long blocking calls during an async function.
@@ -534,8 +534,8 @@ fn main() -> PyResult<()> {
 
 ### Additional Information
 
-- Managing event loop references can be tricky with pyo3-asyncio. See [Event Loop References and ContextVars](https://awestlake87.github.io/pyo3-asyncio/master/doc/pyo3_asyncio/#event-loop-references-and-contextvars) in the API docs to get a better intuition for how event loop references are managed in this library.
-- Testing pyo3-asyncio libraries and applications requires a custom test harness since Python requires control over the main thread. You can find a testing guide in the [API docs for the `testing` module](https://awestlake87.github.io/pyo3-asyncio/master/doc/pyo3_asyncio/testing)
+- Managing event loop references can be tricky with pyo3-asyncio. See [Event Loop References and ContextVars](https://awestlake87.github.io/pyo3-asyncio/master/doc/pyo3_async_runtimes/#event-loop-references-and-contextvars) in the API docs to get a better intuition for how event loop references are managed in this library.
+- Testing pyo3-asyncio libraries and applications requires a custom test harness since Python requires control over the main thread. You can find a testing guide in the [API docs for the `testing` module](https://awestlake87.github.io/pyo3-asyncio/master/doc/pyo3_async_runtimes/testing)
 
 ## Migration Guide
 
@@ -547,7 +547,7 @@ Well, a lot actually. There were some pretty major flaws in the initialization b
 
 To make things a bit easier, I decided to keep most of the old API alongside the new one (with some deprecation warnings to encourage users to move away from it). It should be possible to use the `v0.13` API alongside the newer `v0.14` API, which should allow you to upgrade your application piecemeal rather than all at once.
 
-**Before you get started, I personally recommend taking a look at [Event Loop References and ContextVars](https://awestlake87.github.io/pyo3-asyncio/master/doc/pyo3_asyncio/#event-loop-references-and-contextvars) in order to get a better grasp on the motivation behind these changes and the nuance involved in using the new conversions.**
+**Before you get started, I personally recommend taking a look at [Event Loop References and ContextVars](https://awestlake87.github.io/pyo3-asyncio/master/doc/pyo3_async_runtimes/#event-loop-references-and-contextvars) in order to get a better grasp on the motivation behind these changes and the nuance involved in using the new conversions.**
 
 ### 0.14 Highlights
 
@@ -635,7 +635,7 @@ To make things a bit easier, I decided to keep most of the old API alongside the
    ```
 
 4. Replace conversions with their newer counterparts.
-   > You may encounter some issues regarding the usage of `get_running_loop` vs `get_event_loop`. For more details on these newer conversions and how they should be used see [Event Loop References and ContextVars](https://awestlake87.github.io/pyo3-asyncio/master/doc/pyo3_asyncio/#event-loop-references-and-contextvars).
+   > You may encounter some issues regarding the usage of `get_running_loop` vs `get_event_loop`. For more details on these newer conversions and how they should be used see [Event Loop References and ContextVars](https://awestlake87.github.io/pyo3-asyncio/master/doc/pyo3_async_runtimes/#event-loop-references-and-contextvars).
    - Replace `pyo3_async_runtimes::into_future` with `pyo3_async_runtimes::<runtime>::into_future`
    - Replace `pyo3_async_runtimes::<runtime>::into_coroutine` with `pyo3_async_runtimes::<runtime>::future_into_py`
    - Replace `pyo3_async_runtimes::get_event_loop` with `pyo3_async_runtimes::<runtime>::get_current_loop`

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ Here we initialize the runtime, import Python's `asyncio` library and run the gi
 ```toml
 # Cargo.toml dependencies
 [dependencies]
-pyo3 = { version = "0.20" }
-pyo3-asyncio-0-21 = { version = "0.20", features = ["attributes", "async-std-runtime"] }
-async-std = "1.9"
+pyo3 = { version = "0.22" }
+pyo3-async-runtimes = { version = "0.22", features = ["attributes", "async-std-runtime"] }
+async-std = "1.13"
 ```
 
 ```rust
@@ -84,9 +84,9 @@ attribute.
 ```toml
 # Cargo.toml dependencies
 [dependencies]
-pyo3 = { version = "0.20" }
-pyo3-asyncio-0-21 = { version = "0.20", features = ["attributes", "tokio-runtime"] }
-tokio = "1.9"
+pyo3 = { version = "0.22" }
+pyo3-async-runtimes = { version = "0.22", features = ["attributes", "tokio-runtime"] }
+tokio = "1.40"
 ```
 
 ```rust
@@ -129,9 +129,9 @@ For `async-std`:
 
 ```toml
 [dependencies]
-pyo3 = { version = "0.20", features = ["extension-module"] }
-pyo3-asyncio-0-21 = { version = "0.20", features = ["async-std-runtime"] }
-async-std = "1.9"
+pyo3 = { version = "0.22", features = ["extension-module"] }
+pyo3-async-runtimes = { version = "0.22", features = ["async-std-runtime"] }
+async-std = "1.13"
 ```
 
 For `tokio`:
@@ -139,8 +139,8 @@ For `tokio`:
 ```toml
 [dependencies]
 pyo3 = { version = "0.20", features = ["extension-module"] }
-pyo3-asyncio-0-21 = { version = "0.20", features = ["tokio-runtime"] }
-tokio = "1.9"
+pyo3-async-runtimes = { version = "0.22", features = ["tokio-runtime"] }
+tokio = "1.40"
 ```
 
 Export an async function that makes use of `async-std`:
@@ -228,7 +228,7 @@ to do something special with the object that it returns.
 
 Normally in Python, that something special is the `await` keyword, but in order to await this
 coroutine in Rust, we first need to convert it into Rust's version of a `coroutine`: a `Future`.
-That's where `pyo3-asyncio` comes in.
+That's where `pyo3-async-runtimes` comes in.
 [`pyo3_async_runtimes::into_future`](https://docs.rs/pyo3-asyncio/latest/pyo3_asyncio/fn.into_future.html)
 performs this conversion for us:
 
@@ -433,10 +433,10 @@ name = "my_async_module"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.20", features = ["extension-module"] }
-pyo3-asyncio-0-21 = { version = "0.20", features = ["tokio-runtime"] }
-async-std = "1.9"
-tokio = "1.9"
+pyo3 = { version = "0.22", features = ["extension-module"] }
+pyo3-async-runtimes = { version = "0.22", features = ["tokio-runtime"] }
+async-std = "1.13"
+tokio = "1.40"
 ```
 
 ```rust
@@ -492,9 +492,9 @@ event loop before we can install the `uvloop` policy.
 
 ```toml
 [dependencies]
-async-std = "1.9"
-pyo3 = "0.20"
-pyo3-asyncio-0-21 = { version = "0.20", features = ["async-std-runtime"] }
+async-std = "1.13"
+pyo3 = "0.22"
+pyo3-async-runtimes = { version = "0.22", features = ["async-std-runtime"] }
 ```
 
 ```rust no_run

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ to do something special with the object that it returns.
 Normally in Python, that something special is the `await` keyword, but in order to await this
 coroutine in Rust, we first need to convert it into Rust's version of a `coroutine`: a `Future`.
 That's where `pyo3-async-runtimes` comes in.
-[`pyo3_async_runtimes::into_future`](https://docs.rs/pyo3-asyncio/latest/pyo3_async_runtimes/fn.into_future.html)
+[`pyo3_async_runtimes::into_future`](https://docs.rs/pyo3-async-runtimes/latest/pyo3_async_runtimes/fn.into_future.html)
 performs this conversion for us:
 
 ```rust no_run

--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -8,8 +8,8 @@
 //! are only available when the `unstable-streams` Cargo feature is enabled:
 //!
 //! ```toml
-//! [dependencies.pyo3-asyncio-0-21]
-//! version = "0.21"
+//! [dependencies.pyo3-async-runtimes]
+//! version = "0.22"
 //! features = ["unstable-streams"]
 //! ```
 

--- a/src/err.rs
+++ b/src/err.rs
@@ -3,7 +3,7 @@
 mod exceptions {
     use pyo3::{create_exception, exceptions::PyException};
 
-    create_exception!(pyo3_asyncio, RustPanic, PyException);
+    create_exception!(pyo3_async_runtimes, RustPanic, PyException);
 }
 
 pub use exceptions::RustPanic;

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -8,8 +8,8 @@
 //! > are only available when the `unstable-streams` Cargo feature is enabled:
 //!
 //! ```toml
-//! [dependencies.pyo3-asyncio-0-21]
-//! version = "0.21"
+//! [dependencies.pyo3-async-runtimes]
+//! version = "0.22"
 //! features = ["unstable-streams"]
 //! ```
 
@@ -1651,8 +1651,8 @@ where
             Ok(PyModule::from_code_bound(
                 py,
                 STREAM_GLUE,
-                "pyo3_asyncio/pyo3_asyncio_glue.py",
-                "pyo3_asyncio_glue",
+                "pyo3_async_runtimes/pyo3_async_runtimes_glue.py",
+                "pyo3_async_runtimes_glue",
             )?
             .into())
         })?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -299,8 +299,8 @@
 //! > are only available when the `attributes` Cargo feature is enabled:
 //!
 //! ```toml
-//! [dependencies.pyo3-asyncio-0-21]
-//! version = "0.21"
+//! [dependencies.pyo3-async-runtimes]
+//! version = "0.22"
 //! features = ["attributes"]
 //! ```
 //!
@@ -312,8 +312,8 @@
 //! > are only available when the `async-std-runtime` Cargo feature is enabled:
 //!
 //! ```toml
-//! [dependencies.pyo3-asyncio-0-21]
-//! version = "0.21"
+//! [dependencies.pyo3-async-runtimes]
+//! version = "0.22"
 //! features = ["async-std-runtime"]
 //! ```
 //!
@@ -325,8 +325,8 @@
 //! > are only available when the `tokio-runtime` Cargo feature is enabled:
 //!
 //! ```toml
-//! [dependencies.pyo3-asyncio-0-21]
-//! version = "0.21"
+//! [dependencies.pyo3-async-runtimes]
+//! version = "0.22"
 //! features = ["tokio-runtime"]
 //! ```
 //!
@@ -338,8 +338,8 @@
 //! > are only available when the `testing` Cargo feature is enabled:
 //!
 //! ```toml
-//! [dependencies.pyo3-asyncio-0-21]
-//! version = "0.21"
+//! [dependencies.pyo3-async-runtimes]
+//! version = "0.22"
 //! features = ["testing"]
 //! ```
 
@@ -363,7 +363,7 @@ pub mod err;
 pub mod generic;
 
 #[pymodule]
-fn pyo3_asyncio(py: Python, m: &Bound<PyModule>) -> PyResult<()> {
+fn pyo3_async_runtimes(py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     m.add("RustPanic", py.get_type_bound::<err::RustPanic>())?;
     Ok(())
 }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -7,7 +7,7 @@
 //! harness since it doesn't allow Python to gain control over the main thread. Instead, we have to
 //! provide our own test harness in order to create integration tests.
 //!
-//! Running `pyo3-asyncio` code in doc tests _is_ supported however since each doc test has its own
+//! Running `pyo3-async-runtimes` code in doc tests _is_ supported however since each doc test has its own
 //! `main` function. When writing doc tests, you may use the
 //! [`#[pyo3_async_runtimes::async_std::main]`](crate::async_std::main) or
 //! [`#[pyo3_async_runtimes::tokio::main]`](crate::tokio::main) macros on the test's main function to run
@@ -26,7 +26,7 @@
 //! > The name `pytests` is just a convention. You can name this folder anything you want in your own
 //! > projects.
 //!
-//! We'll also want to provide the test's main function. Most of the functionality that the test harness needs is packed in the [`pyo3_async_runtimes::testing::main`](https://docs.rs/pyo3-asyncio/latest/pyo3_asyncio/testing/fn.main.html) function. This function will parse the test's CLI arguments, collect and pass the functions marked with [`#[pyo3_async_runtimes::async_std::test]`](https://docs.rs/pyo3-asyncio/latest/pyo3_asyncio/async_std/attr.test.html) or [`#[pyo3_async_runtimes::tokio::test]`](https://docs.rs/pyo3-asyncio/latest/pyo3_asyncio/tokio/attr.test.html) and pass them into the test harness for running and filtering.
+//! We'll also want to provide the test's main function. Most of the functionality that the test harness needs is packed in the [`pyo3_async_runtimes::testing::main`](https://docs.rs/pyo3-async-runtimes/latest/pyo3_async_runtimes/testing/fn.main.html) function. This function will parse the test's CLI arguments, collect and pass the functions marked with [`#[pyo3_async_runtimes::async_std::test]`](https://docs.rs/pyo3-async-runtimes/latest/pyo3_async_runtimes/async_std/attr.test.html) or [`#[pyo3_async_runtimes::tokio::test]`](https://docs.rs/pyo3-async-runtimes/latest/pyo3_async_runtimes/tokio/attr.test.html) and pass them into the test harness for running and filtering.
 //!
 //! `pytests/test_example.rs` for the `tokio` runtime:
 //! ```rust
@@ -61,10 +61,10 @@
 //! harness = false
 //! ```
 //!
-//! Also add the `testing` and `attributes` features to the `pyo3-asyncio` dependency and select your preferred runtime:
+//! Also add the `testing` and `attributes` features to the `pyo3-async-runtimes` dependency and select your preferred runtime:
 //!
 //! ```toml
-//! pyo3-asyncio-0-21 = { version = "0.21", features = ["testing", "attributes", "async-std-runtime"] }
+//! pyo3-async-runtimes = { version = "0.22", features = ["testing", "attributes", "async-std-runtime"] }
 //! ```
 //!
 //! At this point, you should be able to run the test via `cargo test`
@@ -73,7 +73,7 @@
 //!
 //! We can add tests anywhere in the test crate with the runtime's corresponding `#[test]` attribute:
 //!
-//! For `async-std` use the [`pyo3_async_runtimes::async_std::test`](https://docs.rs/pyo3-asyncio/latest/pyo3_asyncio/async_std/attr.test.html) attribute:
+//! For `async-std` use the [`pyo3_async_runtimes::async_std::test`](https://docs.rs/pyo3-async-runtimes/latest/pyo3_async_runtimes/async_std/attr.test.html) attribute:
 //! ```rust
 //! # #[cfg(all(feature = "async-std-runtime", feature = "attributes"))]
 //! mod tests {
@@ -105,7 +105,7 @@
 //! # fn main() {}
 //! ```
 //!
-//! For `tokio` use the [`pyo3_async_runtimes::tokio::test`](https://docs.rs/pyo3-asyncio/latest/pyo3_asyncio/tokio/attr.test.html) attribute:
+//! For `tokio` use the [`pyo3_async_runtimes::tokio::test`](https://docs.rs/pyo3-async-runtimes/latest/pyo3_async_runtimes/tokio/attr.test.html) attribute:
 //! ```rust
 //! # #[cfg(all(feature = "tokio-runtime", feature = "attributes"))]
 //! mod tests {
@@ -202,7 +202,7 @@ pub struct Args {
 /// Ideally, we should mirror the default test harness's arguments exactly, but
 /// for the sake of simplicity, only filtering is supported for now. If you want
 /// more features, feel free to request them
-/// [here](https://github.com/awestlake87/pyo3-asyncio/issues).
+/// [here](https://github.com/PyO3/pyo3-async-runtimes/issues).
 ///
 /// # Examples
 ///
@@ -241,7 +241,7 @@ pub fn parse_args() -> Args {
 
 type TestFn = dyn Fn() -> Pin<Box<dyn Future<Output = PyResult<()>> + Send>> + Send + Sync;
 
-/// The structure used by the `#[test]` macros to provide a test to the `pyo3-asyncio` test harness.
+/// The structure used by the `#[test]` macros to provide a test to the `pyo3-async-runtimes` test harness.
 #[derive(Clone)]
 pub struct Test {
     /// The fully qualified name of the test
@@ -286,7 +286,7 @@ pub async fn test_harness(tests: Vec<Test>, args: Args) -> PyResult<()> {
     Ok(())
 }
 
-/// Parses test arguments and passes the tests to the `pyo3-asyncio` test harness
+/// Parses test arguments and passes the tests to the `pyo3-async-runtimes` test harness
 ///
 /// This function collects the test structures from the `inventory` boilerplate and forwards them to
 /// the test harness.

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -8,8 +8,8 @@
 //! >are only available when the `unstable-streams` Cargo feature is enabled:
 //!
 //! ```toml
-//! [dependencies.pyo3-asyncio-0-21]
-//! version = "0.21"
+//! [dependencies.pyo3-async-runtimes]
+//! version = "0.22"
 //! features = ["unstable-streams"]
 //! ```
 


### PR DESCRIPTION
Opening as part of the ongoing effort with https://github.com/PyO3/pyo3-async-runtimes/issues/1. This assumes dropping 3.7 and 3.8 (EOL) is green-lit. I don't know much about the CI setup here, but I'm happy to keep tinkering with it to get this across the line.