### PR TITLE
Update CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,8 @@ jobs:
           [
             {
               os: "macOS-latest",
-              python-architecture: "x64",
-              rust-target: "x86_64-apple-darwin",
+              python-architecture: "aarch64",
+              rust-target: "aarch64-apple-darwin",
             },
             {
               os: "ubuntu-latest",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,14 +53,15 @@ jobs:
             "3.10",
             "3.11",
             "3.12",
+            "3.13",
             "pypy-3.9",
           ]
         platform:
           [
             {
               os: "macos-latest",
-              python-architecture: "x64",
-              rust-target: "x86_64-apple-darwin",
+              python-architecture: "arm64",
+              rust-target: "aarch64-apple-darwin",
             },
             {
               os: "ubuntu-latest",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,11 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
-      - run: pip install black==22.8.0
+      - run: pip install black==24.10.0
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
@@ -32,7 +32,7 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
@@ -114,10 +114,10 @@ jobs:
             extra_features: "nightly"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.platform.python-architecture }}
@@ -160,7 +160,7 @@ jobs:
     needs: [fmt]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: nightly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install gettext (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew install gettext
+          brew link --force gettext
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
@@ -119,12 +125,6 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.platform.rust-target }}
-
-      - name: Install gettext (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          brew install gettext
-          brew link --force gettext
 
       # - if: matrix.platform.os == 'ubuntu-latest'
       #   name: Prepare LD_LIBRARY_PATH (Ubuntu only)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,10 @@ jobs:
         rust: [stable]
         python-version:
           [
-            "3.9-dev",
-            "3.10-dev",
-            "3.11-dev",
-            "3.12-dev",
+            "3.9",
+            "3.10",
+            "3.11",
+            "3.12",
             "pypy-3.9",
           ]
         platform:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
             platform: { os: "windows-latest", python-architecture: "x86" }
         include:
           # Test minimal supported Rust version
-          - rust: 1.63.0
+          - rust: 1.70.0
             python-version: "3.10"
             platform:
               {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,8 @@ jobs:
           [
             {
               os: "macOS-latest",
-              python-architecture: "aarch64",
-              rust-target: "aarch64-apple-darwin",
+              python-architecture: "x64",
+              rust-target: "x86_64-apple-darwin",
             },
             {
               os: "ubuntu-latest",
@@ -107,6 +107,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set DYLD_LIBRARY_PATH (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          echo "DYLD_LIBRARY_PATH=/usr/local/opt/gettext/lib:$DYLD_LIBRARY_PATH" >> $GITHUB_ENV
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,10 +171,10 @@ jobs:
           args: --all-features
         env:
           CARGO_INCREMENTAL: 0
-          RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off"
-          RUSTDOCFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off"
+          RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Cllvm-args=--inline-threshold=0 -Clink-dead-code -Coverflow-checks=off"
+          RUSTDOCFLAGS: "-Zprofile -Ccodegen-units=1 -Cllvm-args=--inline-threshold=0 -Clink-dead-code -Coverflow-checks=off"
       - uses: actions-rs/grcov@v0.1
         id: coverage
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v4
         with:
           file: ${{ steps.coverage.outputs.report }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,13 +49,9 @@ jobs:
         rust: [stable]
         python-version:
           [
-            "3.7",
-            "3.8",
             "3.9",
             "3.10",
             "3.11-dev",
-            "pypy-3.7",
-            "pypy-3.8",
             "pypy-3.9",
           ]
         platform:
@@ -83,10 +79,6 @@ jobs:
           ]
         exclude:
           # PyPy doesn't release 32-bit Windows builds any more
-          - python-version: pypy-3.7
-            platform: { os: "windows-latest", python-architecture: "x86" }
-          - python-version: pypy-3.8
-            platform: { os: "windows-latest", python-architecture: "x86" }
           - python-version: pypy-3.9
             platform: { os: "windows-latest", python-architecture: "x86" }
         include:
@@ -127,6 +119,12 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.platform.rust-target }}
+
+      - name: Install gettext (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew install gettext
+          brew link --force gettext
 
       # - if: matrix.platform.os == 'ubuntu-latest'
       #   name: Prepare LD_LIBRARY_PATH (Ubuntu only)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,12 +108,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install gettext (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          brew install gettext
-          brew link --force gettext
-
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
             platform: { os: "windows-latest", python-architecture: "x86" }
         include:
           # Test minimal supported Rust version
-          - rust: 1.70.0
+          - rust: 1.63.0
             python-version: "3.10"
             platform:
               {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,15 +49,16 @@ jobs:
         rust: [stable]
         python-version:
           [
-            "3.9",
-            "3.10",
+            "3.9-dev",
+            "3.10-dev",
             "3.11-dev",
+            "3.12-dev",
             "pypy-3.9",
           ]
         platform:
           [
             {
-              os: "macOS-latest",
+              os: "macos-latest",
               python-architecture: "x64",
               rust-target: "x86_64-apple-darwin",
             },
@@ -107,11 +108,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Set DYLD_LIBRARY_PATH (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          echo "DYLD_LIBRARY_PATH=/usr/local/opt/gettext/lib:$DYLD_LIBRARY_PATH" >> $GITHUB_ENV
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["api-bindings", "development-tools::ffi"]
 license = "Apache-2.0"
 exclude = ["/.gitignore", "/codecov.yml", "/Makefile"]
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.70"
 
 [workspace]
 members = ["pyo3-asyncio-macros"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["api-bindings", "development-tools::ffi"]
 license = "Apache-2.0"
 exclude = ["/.gitignore", "/codecov.yml", "/Makefile"]
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.63"
 
 [workspace]
 members = ["pyo3-asyncio-macros"]


### PR DESCRIPTION
Upgrades the action versions and `black` in the `ci.yml` workflow, and adds Python 3.13 to the build matrix.

~~As a test, I've also taken the liberty of bumping up the MSRV from 1.63 to 1.70 so that the latest `tokio` can be supported, which fixes the MSRV CI job. (I could do this in a separate PR, or we could adjust the approach here.)~~

I've also made the bold move of dropping Python 3.7 and 3.8 in CI. (I can also revert this.)