### PR TITLE
Bump to 0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pyo3-async-runtimes"
 description = "PyO3 bridges from Rust runtimes to Python's Asyncio library"
-version = "0.22.0"
+version = "0.23.0"
 authors = [
     "Andrew J Westlake <awestlake87@yahoo.com>",
     "David Hewitt <mail@davidhewitt.dev>",
@@ -120,11 +120,11 @@ futures = "0.3"
 inventory = { version = "0.3", optional = true }
 once_cell = "1.14"
 pin-project-lite = "0.2"
-pyo3 = "0.22"
-pyo3-async-runtimes-macros = { path = "pyo3-async-runtimes-macros", version = "=0.22.0", optional = true }
+pyo3 = "0.23"
+pyo3-async-runtimes-macros = { path = "pyo3-async-runtimes-macros", version = "=0.23.0", optional = true }
 
 [dev-dependencies]
-pyo3 = { version = "0.22", features = ["macros"] }
+pyo3 = { version = "0.23", features = ["macros"] }
 
 [dependencies.async-std]
 version = "1.12"

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ async fn main() -> PyResult<()> {
     let fut = Python::with_gil(|py| {
         let asyncio = py.import("asyncio")?;
         // convert asyncio.sleep into a Rust Future
-        pyo3_async_runtimes::async_std::into_future(asyncio.call_method1("sleep", (1.into_py(py),))?)
+        pyo3_async_runtimes::async_std::into_future(asyncio.call_method1("sleep", (1.into_pyobject(py).unwrap(),))?)
     })?;
 
     fut.await?;
@@ -99,7 +99,7 @@ async fn main() -> PyResult<()> {
     let fut = Python::with_gil(|py| {
         let asyncio = py.import("asyncio")?;
         // convert asyncio.sleep into a Rust Future
-        pyo3_async_runtimes::tokio::into_future(asyncio.call_method1("sleep", (1.into_py(py),))?)
+        pyo3_async_runtimes::tokio::into_future(asyncio.call_method1("sleep", (1.into_pyobject(py).unwrap(),))?)
     })?;
 
     fut.await?;
@@ -363,7 +363,7 @@ async fn main() -> PyResult<()> {
 
         // convert asyncio.sleep into a Rust Future
         pyo3_async_runtimes::async_std::into_future(
-            asyncio.call_method1("sleep", (1.into_py(py),))?
+            asyncio.call_method1("sleep", (1.into_pyobject(py).unwrap(),))?
         )
     })?;
 

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ Here we initialize the runtime, import Python's `asyncio` library and run the gi
 ```toml
 # Cargo.toml dependencies
 [dependencies]
-pyo3 = { version = "0.22" }
-pyo3-async-runtimes = { version = "0.22", features = ["attributes", "async-std-runtime"] }
+pyo3 = { version = "0.23" }
+pyo3-async-runtimes = { version = "0.23", features = ["attributes", "async-std-runtime"] }
 async-std = "1.13"
 ```
 
@@ -84,8 +84,8 @@ attribute.
 ```toml
 # Cargo.toml dependencies
 [dependencies]
-pyo3 = { version = "0.22" }
-pyo3-async-runtimes = { version = "0.22", features = ["attributes", "tokio-runtime"] }
+pyo3 = { version = "0.23" }
+pyo3-async-runtimes = { version = "0.23", features = ["attributes", "tokio-runtime"] }
 tokio = "1.40"
 ```
 
@@ -130,8 +130,8 @@ For `async-std`:
 
 ```toml
 [dependencies]
-pyo3 = { version = "0.22", features = ["extension-module"] }
-pyo3-async-runtimes = { version = "0.22", features = ["async-std-runtime"] }
+pyo3 = { version = "0.23", features = ["extension-module"] }
+pyo3-async-runtimes = { version = "0.23", features = ["async-std-runtime"] }
 async-std = "1.13"
 ```
 
@@ -140,7 +140,7 @@ For `tokio`:
 ```toml
 [dependencies]
 pyo3 = { version = "0.20", features = ["extension-module"] }
-pyo3-async-runtimes = { version = "0.22", features = ["tokio-runtime"] }
+pyo3-async-runtimes = { version = "0.23", features = ["tokio-runtime"] }
 tokio = "1.40"
 ```
 
@@ -434,8 +434,8 @@ name = "my_async_module"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.22", features = ["extension-module"] }
-pyo3-async-runtimes = { version = "0.22", features = ["tokio-runtime"] }
+pyo3 = { version = "0.23", features = ["extension-module"] }
+pyo3-async-runtimes = { version = "0.23", features = ["tokio-runtime"] }
 async-std = "1.13"
 tokio = "1.40"
 ```
@@ -494,8 +494,8 @@ event loop before we can install the `uvloop` policy.
 ```toml
 [dependencies]
 async-std = "1.13"
-pyo3 = "0.22"
-pyo3-async-runtimes = { version = "0.22", features = ["async-std-runtime"] }
+pyo3 = "0.23"
+pyo3-async-runtimes = { version = "0.23", features = ["async-std-runtime"] }
 ```
 
 ```rust no_run

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ use pyo3::prelude::*;
 #[pyo3_async_runtimes::async_std::main]
 async fn main() -> PyResult<()> {
     let fut = Python::with_gil(|py| {
-        let asyncio = py.import_bound("asyncio")?;
+        let asyncio = py.import("asyncio")?;
         // convert asyncio.sleep into a Rust Future
         pyo3_async_runtimes::async_std::into_future(asyncio.call_method1("sleep", (1.into_py(py),))?)
     })?;
@@ -97,7 +97,7 @@ use pyo3::prelude::*;
 #[pyo3_async_runtimes::tokio::main]
 async fn main() -> PyResult<()> {
     let fut = Python::with_gil(|py| {
-        let asyncio = py.import_bound("asyncio")?;
+        let asyncio = py.import("asyncio")?;
         // convert asyncio.sleep into a Rust Future
         pyo3_async_runtimes::tokio::into_future(asyncio.call_method1("sleep", (1.into_py(py),))?)
     })?;
@@ -240,7 +240,7 @@ use pyo3::prelude::*;
 async fn main() -> PyResult<()> {
     let future = Python::with_gil(|py| -> PyResult<_> {
         // import the module containing the py_sleep function
-        let example = py.import_bound("example")?;
+        let example = py.import("example")?;
 
         // calling the py_sleep method like a normal function
         // returns a coroutine
@@ -359,7 +359,7 @@ async fn main() -> PyResult<()> {
     // PyO3 is initialized - Ready to go
 
     let fut = Python::with_gil(|py| -> PyResult<_> {
-        let asyncio = py.import_bound("asyncio")?;
+        let asyncio = py.import("asyncio")?;
 
         // convert asyncio.sleep into a Rust Future
         pyo3_async_runtimes::async_std::into_future(
@@ -507,7 +507,7 @@ fn main() -> PyResult<()> {
     pyo3::prepare_freethreaded_python();
 
     Python::with_gil(|py| {
-        let uvloop = py.import_bound("uvloop")?;
+        let uvloop = py.import("uvloop")?;
         uvloop.call_method0("install")?;
 
         // store a reference for the assertion
@@ -604,7 +604,7 @@ To make things a bit easier, I decided to keep most of the old API alongside the
        pyo3::prepare_freethreaded_python();
 
        Python::with_gil(|py| {
-           let asyncio = py.import_bound("asyncio")?;
+           let asyncio = py.import("asyncio")?;
 
            let event_loop = asyncio.call_method0("new_event_loop")?;
            asyncio.call_method1("set_event_loop", (&event_loop,))?;

--- a/examples/async_std.rs
+++ b/examples/async_std.rs
@@ -3,11 +3,11 @@ use pyo3::prelude::*;
 #[pyo3_async_runtimes::async_std::main]
 async fn main() -> PyResult<()> {
     let fut = Python::with_gil(|py| {
-        let asyncio = py.import_bound("asyncio")?;
+        let asyncio = py.import("asyncio")?;
 
         // convert asyncio.sleep into a Rust Future
         pyo3_async_runtimes::async_std::into_future(
-            asyncio.call_method1("sleep", (1.into_py(py),))?,
+            asyncio.call_method1("sleep", (1.into_pyobject(py).unwrap(),))?,
         )
     })?;
 

--- a/examples/tokio.rs
+++ b/examples/tokio.rs
@@ -3,10 +3,12 @@ use pyo3::prelude::*;
 #[pyo3_async_runtimes::tokio::main]
 async fn main() -> PyResult<()> {
     let fut = Python::with_gil(|py| {
-        let asyncio = py.import_bound("asyncio")?;
+        let asyncio = py.import("asyncio")?;
 
         // convert asyncio.sleep into a Rust Future
-        pyo3_async_runtimes::tokio::into_future(asyncio.call_method1("sleep", (1.into_py(py),))?)
+        pyo3_async_runtimes::tokio::into_future(
+            asyncio.call_method1("sleep", (1.into_pyobject(py).unwrap(),))?,
+        )
     })?;
 
     println!("sleeping for 1s");

--- a/examples/tokio_current_thread.rs
+++ b/examples/tokio_current_thread.rs
@@ -3,10 +3,12 @@ use pyo3::prelude::*;
 #[pyo3_async_runtimes::tokio::main(flavor = "current_thread")]
 async fn main() -> PyResult<()> {
     let fut = Python::with_gil(|py| {
-        let asyncio = py.import_bound("asyncio")?;
+        let asyncio = py.import("asyncio")?;
 
         // convert asyncio.sleep into a Rust Future
-        pyo3_async_runtimes::tokio::into_future(asyncio.call_method1("sleep", (1.into_py(py),))?)
+        pyo3_async_runtimes::tokio::into_future(
+            asyncio.call_method1("sleep", (1.into_pyobject(py).unwrap(),))?,
+        )
     })?;
 
     println!("sleeping for 1s");

--- a/examples/tokio_multi_thread.rs
+++ b/examples/tokio_multi_thread.rs
@@ -3,10 +3,12 @@ use pyo3::prelude::*;
 #[pyo3_async_runtimes::tokio::main(flavor = "multi_thread", worker_threads = 10)]
 async fn main() -> PyResult<()> {
     let fut = Python::with_gil(|py| {
-        let asyncio = py.import_bound("asyncio")?;
+        let asyncio = py.import("asyncio")?;
 
         // convert asyncio.sleep into a Rust Future
-        pyo3_async_runtimes::tokio::into_future(asyncio.call_method1("sleep", (1.into_py(py),))?)
+        pyo3_async_runtimes::tokio::into_future(
+            asyncio.call_method1("sleep", (1.into_pyobject(py).unwrap(),))?,
+        )
     })?;
 
     println!("sleeping for 1s");

--- a/pyo3-async-runtimes-macros/Cargo.toml
+++ b/pyo3-async-runtimes-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pyo3-async-runtimes-macros"
 description = "Proc Macro Attributes for `pyo3-async-runtimes`"
-version = "0.22.0"
+version = "0.23.0"
 authors = [
     "Andrew J Westlake <awestlake87@yahoo.com>",
     "David Hewitt <mail@davidhewitt.dev>",

--- a/pytests/test_async_std_asyncio.rs
+++ b/pytests/test_async_std_asyncio.rs
@@ -1,5 +1,6 @@
 mod common;
 
+use std::ffi::CString;
 use std::{
     rc::Rc,
     sync::{Arc, Mutex},
@@ -30,15 +31,15 @@ fn sleep<'p>(py: Python<'p>, secs: Bound<'p, PyAny>) -> PyResult<Bound<'p, PyAny
 #[pyo3_async_runtimes::async_std::test]
 async fn test_future_into_py() -> PyResult<()> {
     let fut = Python::with_gil(|py| {
-        let sleeper_mod = PyModule::new_bound(py, "rust_sleeper")?;
+        let sleeper_mod = PyModule::new(py, "rust_sleeper")?;
 
         sleeper_mod.add_wrapped(wrap_pyfunction!(sleep))?;
 
-        let test_mod = PyModule::from_code_bound(
+        let test_mod = PyModule::from_code(
             py,
-            common::TEST_MOD,
-            "test_future_into_py_mod.py",
-            "test_future_into_py_mod",
+            &CString::new(common::TEST_MOD).unwrap(),
+            &CString::new("test_future_into_py_mod.py").unwrap(),
+            &CString::new("test_future_into_py_mod").unwrap(),
         )?;
 
         pyo3_async_runtimes::async_std::into_future(
@@ -53,10 +54,7 @@ async fn test_future_into_py() -> PyResult<()> {
 
 #[pyo3_async_runtimes::async_std::test]
 async fn test_async_sleep() -> PyResult<()> {
-    let asyncio = Python::with_gil(|py| {
-        py.import_bound("asyncio")
-            .map(|asyncio| PyObject::from(asyncio))
-    })?;
+    let asyncio = Python::with_gil(|py| py.import("asyncio").map(PyObject::from))?;
 
     task::sleep(Duration::from_secs(1)).await;
 
@@ -157,8 +155,8 @@ async fn test_cancel() -> PyResult<()> {
     .await
     {
         Python::with_gil(|py| -> PyResult<()> {
-            assert!(e.value_bound(py).is_instance(
-                py.import_bound("asyncio")?
+            assert!(e.value(py).is_instance(
+                py.import("asyncio")?
                     .getattr("CancelledError")?
                     .downcast::<PyType>()
                     .unwrap()
@@ -191,18 +189,18 @@ async def gen():
 #[pyo3_async_runtimes::async_std::test]
 async fn test_async_gen_v1() -> PyResult<()> {
     let stream = Python::with_gil(|py| {
-        let test_mod = PyModule::from_code_bound(
+        let test_mod = PyModule::from_code(
             py,
-            ASYNC_STD_TEST_MOD,
-            "test_rust_coroutine/async_std_test_mod.py",
-            "async_std_test_mod",
+            &CString::new(ASYNC_STD_TEST_MOD).unwrap(),
+            &CString::new("test_rust_coroutine/async_std_test_mod.py").unwrap(),
+            &CString::new("async_std_test_mod").unwrap(),
         )?;
 
         pyo3_async_runtimes::async_std::into_stream_v1(test_mod.call_method0("gen")?)
     })?;
 
     let vals = stream
-        .map(|item| Python::with_gil(|py| -> PyResult<i32> { Ok(item?.bind(py).extract()?) }))
+        .map(|item| Python::with_gil(|py| -> PyResult<i32> { item?.bind(py).extract() }))
         .try_collect::<Vec<i32>>()
         .await?;
 
@@ -214,7 +212,7 @@ async fn test_async_gen_v1() -> PyResult<()> {
 #[pyo3_async_runtimes::async_std::test]
 fn test_local_cancel(event_loop: PyObject) -> PyResult<()> {
     let locals = Python::with_gil(|py| -> PyResult<TaskLocals> {
-        Ok(TaskLocals::new(event_loop.into_bound(py)).copy_context(py)?)
+        TaskLocals::new(event_loop.into_bound(py)).copy_context(py)
     })?;
     async_std::task::block_on(pyo3_async_runtimes::async_std::scope_local(locals, async {
         let completed = Arc::new(Mutex::new(false));
@@ -239,8 +237,8 @@ fn test_local_cancel(event_loop: PyObject) -> PyResult<()> {
         .await
         {
             Python::with_gil(|py| -> PyResult<()> {
-                assert!(e.value_bound(py).is_instance(
-                    py.import_bound("asyncio")?
+                assert!(e.value(py).is_instance(
+                    py.import("asyncio")?
                         .getattr("CancelledError")?
                         .downcast::<PyType>()
                         .unwrap()
@@ -297,13 +295,13 @@ fn test_multiple_asyncio_run() -> PyResult<()> {
         })?;
 
         let d = [
-            ("asyncio", py.import_bound("asyncio")?.into()),
+            ("asyncio", py.import("asyncio")?.into()),
             ("test_mod", wrap_pymodule!(test_mod)(py)),
         ]
-        .into_py_dict_bound(py);
+        .into_py_dict(py)?;
 
-        py.run_bound(MULTI_ASYNCIO_CODE, Some(&d), None)?;
-        py.run_bound(MULTI_ASYNCIO_CODE, Some(&d), None)?;
+        py.run(&CString::new(MULTI_ASYNCIO_CODE).unwrap(), Some(&d), None)?;
+        py.run(&CString::new(MULTI_ASYNCIO_CODE).unwrap(), Some(&d), None)?;
         Ok(())
     })
 }
@@ -332,18 +330,18 @@ fn cvars_mod(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
 #[pyo3_async_runtimes::async_std::test]
 async fn test_async_gen_v2() -> PyResult<()> {
     let stream = Python::with_gil(|py| {
-        let test_mod = PyModule::from_code_bound(
+        let test_mod = PyModule::from_code(
             py,
-            ASYNC_STD_TEST_MOD,
-            "test_rust_coroutine/async_std_test_mod.py",
-            "async_std_test_mod",
+            &CString::new(ASYNC_STD_TEST_MOD).unwrap(),
+            &CString::new("test_rust_coroutine/async_std_test_mod.py").unwrap(),
+            &CString::new("async_std_test_mod").unwrap(),
         )?;
 
         pyo3_async_runtimes::async_std::into_stream_v2(test_mod.call_method0("gen")?)
     })?;
 
     let vals = stream
-        .map(|item| Python::with_gil(|py| -> PyResult<i32> { Ok(item.bind(py).extract()?) }))
+        .map(|item| Python::with_gil(|py| -> PyResult<i32> { item.bind(py).extract() }))
         .try_collect::<Vec<i32>>()
         .await?;
 
@@ -369,14 +367,14 @@ asyncio.run(main())
 fn test_contextvars() -> PyResult<()> {
     Python::with_gil(|py| {
         let d = [
-            ("asyncio", py.import_bound("asyncio")?.into()),
-            ("contextvars", py.import_bound("contextvars")?.into()),
+            ("asyncio", py.import("asyncio")?.into()),
+            ("contextvars", py.import("contextvars")?.into()),
             ("cvars_mod", wrap_pymodule!(cvars_mod)(py)),
         ]
-        .into_py_dict_bound(py);
+        .into_py_dict(py)?;
 
-        py.run_bound(CONTEXTVARS_CODE, Some(&d), None)?;
-        py.run_bound(CONTEXTVARS_CODE, Some(&d), None)?;
+        py.run(&CString::new(CONTEXTVARS_CODE).unwrap(), Some(&d), None)?;
+        py.run(&CString::new(CONTEXTVARS_CODE).unwrap(), Some(&d), None)?;
         Ok(())
     })
 }

--- a/pytests/test_async_std_run_forever.rs
+++ b/pytests/test_async_std_run_forever.rs
@@ -12,7 +12,7 @@ fn main() {
     pyo3::prepare_freethreaded_python();
 
     Python::with_gil(|py| {
-        let asyncio = py.import_bound("asyncio")?;
+        let asyncio = py.import("asyncio")?;
 
         let event_loop = asyncio.call_method0("new_event_loop")?;
         asyncio.call_method1("set_event_loop", (&event_loop,))?;

--- a/pytests/test_async_std_uvloop.rs
+++ b/pytests/test_async_std_uvloop.rs
@@ -4,7 +4,7 @@ fn main() -> pyo3::PyResult<()> {
     pyo3::prepare_freethreaded_python();
 
     Python::with_gil(|py| {
-        let uvloop = py.import_bound("uvloop")?;
+        let uvloop = py.import("uvloop")?;
         uvloop.call_method0("install")?;
 
         // store a reference for the assertion

--- a/pytests/test_race_condition_regression.rs
+++ b/pytests/test_race_condition_regression.rs
@@ -1,3 +1,5 @@
+use std::ffi::CString;
+
 use pyo3::{prelude::*, wrap_pyfunction};
 
 #[pyfunction]
@@ -49,15 +51,15 @@ fn main() -> pyo3::PyResult<()> {
     pyo3::prepare_freethreaded_python();
 
     Python::with_gil(|py| -> PyResult<()> {
-        let sleeper_mod = PyModule::new_bound(py, "rust_sleeper")?;
+        let sleeper_mod = PyModule::new(py, "rust_sleeper")?;
 
         sleeper_mod.add_wrapped(wrap_pyfunction!(sleep))?;
 
-        let test_mod = PyModule::from_code_bound(
+        let test_mod = PyModule::from_code(
             py,
-            RACE_CONDITION_REGRESSION_TEST,
-            "race_condition_regression_test.py",
-            "race_condition_regression_test",
+            &CString::new(RACE_CONDITION_REGRESSION_TEST).unwrap(),
+            &CString::new("race_condition_regression_test.py").unwrap(),
+            &CString::new("race_condition_regression_test").unwrap(),
         )?;
 
         test_mod.call_method1("main", (sleeper_mod.getattr("sleep")?,))?;

--- a/pytests/test_tokio_current_thread_uvloop.rs
+++ b/pytests/test_tokio_current_thread_uvloop.rs
@@ -13,7 +13,7 @@ fn main() -> pyo3::PyResult<()> {
     });
 
     Python::with_gil(|py| {
-        let uvloop = py.import_bound("uvloop")?;
+        let uvloop = py.import("uvloop")?;
         uvloop.call_method0("install")?;
 
         // store a reference for the assertion

--- a/pytests/test_tokio_multi_thread_uvloop.rs
+++ b/pytests/test_tokio_multi_thread_uvloop.rs
@@ -5,7 +5,7 @@ fn main() -> pyo3::PyResult<()> {
     pyo3::prepare_freethreaded_python();
 
     Python::with_gil(|py| {
-        let uvloop = py.import_bound("uvloop")?;
+        let uvloop = py.import("uvloop")?;
         uvloop.call_method0("install")?;
 
         // store a reference for the assertion

--- a/pytests/tokio_run_forever/mod.rs
+++ b/pytests/tokio_run_forever/mod.rs
@@ -10,7 +10,7 @@ fn dump_err(py: Python<'_>, e: PyErr) {
 
 pub(super) fn test_main() {
     Python::with_gil(|py| {
-        let asyncio = py.import_bound("asyncio")?;
+        let asyncio = py.import("asyncio")?;
 
         let event_loop = asyncio.call_method0("new_event_loop")?;
         asyncio.call_method1("set_event_loop", (&event_loop,))?;

--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -485,6 +485,7 @@ where
 ///
 /// ```
 /// use std::time::Duration;
+/// use std::ffi::CString;
 ///
 /// use pyo3::prelude::*;
 ///
@@ -498,11 +499,11 @@ where
 /// async fn py_sleep(seconds: f32) -> PyResult<()> {
 ///     let test_mod = Python::with_gil(|py| -> PyResult<PyObject> {
 ///         Ok(
-///             PyModule::from_code_bound(
+///             PyModule::from_code(
 ///                 py,
-///                 PYTHON_CODE,
-///                 "test_into_future/test_mod.py",
-///                 "test_mod"
+///                 &CString::new(PYTHON_CODE).unwrap(),
+///                 &CString::new("test_into_future/test_mod.py").unwrap(),
+///                 &CString::new("test_mod").unwrap()
 ///             )?
 ///             .into()
 ///         )
@@ -552,11 +553,11 @@ pub fn into_future(
 /// # #[pyo3_async_runtimes::async_std::main]
 /// # async fn main() -> PyResult<()> {
 /// let stream = Python::with_gil(|py| {
-///     let test_mod = PyModule::from_code_bound(
+///     let test_mod = PyModule::from_code(
 ///         py,
-///         TEST_MOD,
-///         "test_rust_coroutine/test_mod.py",
-///         "test_mod",
+///         &CString::new(TEST_MOD).unwrap(),
+///         &CString::new("test_rust_coroutine/test_mod.py").unwrap(),
+///         &CString::new("test_mod").unwrap(),
 ///     )?;
 ///
 ///     pyo3_async_runtimes::async_std::into_stream_v1(test_mod.call_method0("gen")?)
@@ -595,6 +596,7 @@ pub fn into_stream_v1(
 /// ```
 /// use pyo3::prelude::*;
 /// use futures::{StreamExt, TryStreamExt};
+/// use std::ffi::CString;
 ///
 /// const TEST_MOD: &str = r#"
 /// import asyncio
@@ -609,11 +611,11 @@ pub fn into_stream_v1(
 /// # #[pyo3_async_runtimes::async_std::main]
 /// # async fn main() -> PyResult<()> {
 /// let stream = Python::with_gil(|py| {
-///     let test_mod = PyModule::from_code_bound(
+///     let test_mod = PyModule::from_code(
 ///         py,
-///         TEST_MOD,
-///         "test_rust_coroutine/test_mod.py",
-///         "test_mod",
+///         &CString::new(TEST_MOD).unwrap(),
+///         &CString::new("test_rust_coroutine/test_mod.py").unwrap(),
+///         &CString::new("test_mod").unwrap(),
 ///     )?;
 ///
 ///     pyo3_async_runtimes::async_std::into_stream_with_locals_v1(
@@ -656,6 +658,7 @@ pub fn into_stream_with_locals_v1(
 /// ```
 /// use pyo3::prelude::*;
 /// use futures::{StreamExt, TryStreamExt};
+/// use std::ffi::CString;
 ///
 /// const TEST_MOD: &str = r#"
 /// import asyncio
@@ -670,11 +673,11 @@ pub fn into_stream_with_locals_v1(
 /// # #[pyo3_async_runtimes::async_std::main]
 /// # async fn main() -> PyResult<()> {
 /// let stream = Python::with_gil(|py| {
-///     let test_mod = PyModule::from_code_bound(
+///     let test_mod = PyModule::from_code(
 ///         py,
-///         TEST_MOD,
-///         "test_rust_coroutine/test_mod.py",
-///         "test_mod",
+///         &CString::new(TEST_MOD).unwrap(),
+///         &CString::new("test_rust_coroutine/test_mod.py").unwrap(),
+///         &CString::new("test_mod").unwrap(),
 ///     )?;
 ///
 ///     pyo3_async_runtimes::async_std::into_stream_with_locals_v2(
@@ -716,6 +719,7 @@ pub fn into_stream_with_locals_v2(
 /// ```
 /// use pyo3::prelude::*;
 /// use futures::{StreamExt, TryStreamExt};
+/// use std::ffi::CString;
 ///
 /// const TEST_MOD: &str = r#"
 /// import asyncio
@@ -730,11 +734,11 @@ pub fn into_stream_with_locals_v2(
 /// # #[pyo3_async_runtimes::async_std::main]
 /// # async fn main() -> PyResult<()> {
 /// let stream = Python::with_gil(|py| {
-///     let test_mod = PyModule::from_code_bound(
+///     let test_mod = PyModule::from_code(
 ///         py,
-///         TEST_MOD,
-///         "test_rust_coroutine/test_mod.py",
-///         "test_mod",
+///         &CString::new(TEST_MOD).unwrap(),
+///         &CString::new("test_rust_coroutine/test_mod.py").unwrap(),
+///         &CString::new("test_mod").unwrap(),
 ///     )?;
 ///
 ///     pyo3_async_runtimes::async_std::into_stream_v2(test_mod.call_method0("gen")?)

--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -272,17 +272,16 @@ where
 ///     )
 /// }
 /// ```
-pub fn future_into_py_with_locals<F, T, P>(
+pub fn future_into_py_with_locals<F, T>(
     py: Python,
     locals: TaskLocals,
     fut: F,
 ) -> PyResult<Bound<PyAny>>
 where
     F: Future<Output = PyResult<T>> + Send + 'static,
-    T: for<'py> IntoPyObject<'py, Target = P>,
-    P: AsRef<PyAny>,
+    T: for<'py> IntoPyObject<'py>,
 {
-    generic::future_into_py_with_locals::<AsyncStdRuntime, F, T, P>(py, locals, fut)
+    generic::future_into_py_with_locals::<AsyncStdRuntime, F, T>(py, locals, fut)
 }
 
 /// Convert a Rust Future into a Python awaitable
@@ -323,13 +322,12 @@ where
 ///     })
 /// }
 /// ```
-pub fn future_into_py<F, T, P>(py: Python, fut: F) -> PyResult<Bound<PyAny>>
+pub fn future_into_py<F, T>(py: Python, fut: F) -> PyResult<Bound<PyAny>>
 where
     F: Future<Output = PyResult<T>> + Send + 'static,
-    T: for<'py> IntoPyObject<'py, Target = P>,
-    P: AsRef<PyAny>,
+    T: for<'py> IntoPyObject<'py>,
 {
-    generic::future_into_py::<AsyncStdRuntime, _, T, P>(py, fut)
+    generic::future_into_py::<AsyncStdRuntime, _, T>(py, fut)
 }
 
 /// Convert a `!Send` Rust Future into a Python awaitable
@@ -395,17 +393,16 @@ where
     note = "Questionable whether these conversions have real-world utility (see https://github.com/awestlake87/pyo3-asyncio/issues/59#issuecomment-1008038497 and let me know if you disagree!)"
 )]
 #[allow(deprecated)]
-pub fn local_future_into_py_with_locals<F, T, P>(
+pub fn local_future_into_py_with_locals<F, T>(
     py: Python,
     locals: TaskLocals,
     fut: F,
 ) -> PyResult<Bound<PyAny>>
 where
     F: Future<Output = PyResult<T>> + 'static,
-    T: for<'py> IntoPyObject<'py, Target = P>,
-    P: AsRef<PyAny>,
+    T: for<'py> IntoPyObject<'py>,
 {
-    generic::local_future_into_py_with_locals::<AsyncStdRuntime, _, T, P>(py, locals, fut)
+    generic::local_future_into_py_with_locals::<AsyncStdRuntime, _, T>(py, locals, fut)
 }
 
 /// Convert a `!Send` Rust Future into a Python awaitable
@@ -466,13 +463,12 @@ where
     note = "Questionable whether these conversions have real-world utility (see https://github.com/awestlake87/pyo3-asyncio/issues/59#issuecomment-1008038497 and let me know if you disagree!)"
 )]
 #[allow(deprecated)]
-pub fn local_future_into_py<F, T, P>(py: Python, fut: F) -> PyResult<Bound<PyAny>>
+pub fn local_future_into_py<F, T>(py: Python, fut: F) -> PyResult<Bound<PyAny>>
 where
     F: Future<Output = PyResult<T>> + 'static,
-    T: for<'py> IntoPyObject<'py, Target = P>,
-    P: AsRef<PyAny>,
+    T: for<'py> IntoPyObject<'py>,
 {
-    generic::local_future_into_py::<AsyncStdRuntime, _, T, _>(py, fut)
+    generic::local_future_into_py::<AsyncStdRuntime, _, T>(py, fut)
 }
 
 /// Convert a Python `awaitable` into a Rust Future

--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -9,7 +9,7 @@
 //!
 //! ```toml
 //! [dependencies.pyo3-async-runtimes]
-//! version = "0.22"
+//! version = "0.23"
 //! features = ["unstable-streams"]
 //! ```
 
@@ -272,14 +272,14 @@ where
 ///     )
 /// }
 /// ```
-pub fn future_into_py_with_locals<F, T>(
+pub fn future_into_py_with_locals<'py, F, T>(
     py: Python,
     locals: TaskLocals,
     fut: F,
 ) -> PyResult<Bound<PyAny>>
 where
     F: Future<Output = PyResult<T>> + Send + 'static,
-    T: IntoPy<PyObject>,
+    T: IntoPyObject<'py>,
 {
     generic::future_into_py_with_locals::<AsyncStdRuntime, F, T>(py, locals, fut)
 }
@@ -322,10 +322,10 @@ where
 ///     })
 /// }
 /// ```
-pub fn future_into_py<F, T>(py: Python, fut: F) -> PyResult<Bound<PyAny>>
+pub fn future_into_py<'py, F, T>(py: Python, fut: F) -> PyResult<Bound<PyAny>>
 where
     F: Future<Output = PyResult<T>> + Send + 'static,
-    T: IntoPy<PyObject>,
+    T: IntoPyObject<'py>,
 {
     generic::future_into_py::<AsyncStdRuntime, _, T>(py, fut)
 }
@@ -393,14 +393,14 @@ where
     note = "Questionable whether these conversions have real-world utility (see https://github.com/awestlake87/pyo3-asyncio/issues/59#issuecomment-1008038497 and let me know if you disagree!)"
 )]
 #[allow(deprecated)]
-pub fn local_future_into_py_with_locals<F, T>(
+pub fn local_future_into_py_with_locals<'py, F, T>(
     py: Python,
     locals: TaskLocals,
     fut: F,
 ) -> PyResult<Bound<PyAny>>
 where
     F: Future<Output = PyResult<T>> + 'static,
-    T: IntoPy<PyObject>,
+    T: IntoPyObject<'py>,
 {
     generic::local_future_into_py_with_locals::<AsyncStdRuntime, _, T>(py, locals, fut)
 }
@@ -463,10 +463,10 @@ where
     note = "Questionable whether these conversions have real-world utility (see https://github.com/awestlake87/pyo3-asyncio/issues/59#issuecomment-1008038497 and let me know if you disagree!)"
 )]
 #[allow(deprecated)]
-pub fn local_future_into_py<F, T>(py: Python, fut: F) -> PyResult<Bound<PyAny>>
+pub fn local_future_into_py<'py, F, T>(py: Python, fut: F) -> PyResult<Bound<PyAny>>
 where
     F: Future<Output = PyResult<T>> + 'static,
-    T: IntoPy<PyObject>,
+    T: IntoPyObject<'py>,
 {
     generic::local_future_into_py::<AsyncStdRuntime, _, T>(py, fut)
 }

--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -176,7 +176,7 @@ pub fn get_current_locals(py: Python) -> PyResult<TaskLocals> {
 /// # pyo3::prepare_freethreaded_python();
 /// #
 /// # Python::with_gil(|py| -> PyResult<()> {
-/// # let event_loop = py.import_bound("asyncio")?.call_method0("new_event_loop")?;
+/// # let event_loop = py.import("asyncio")?.call_method0("new_event_loop")?;
 /// pyo3_async_runtimes::async_std::run_until_complete(event_loop, async move {
 ///     async_std::task::sleep(Duration::from_secs(1)).await;
 ///     Ok(())

--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -272,16 +272,17 @@ where
 ///     )
 /// }
 /// ```
-pub fn future_into_py_with_locals<'py, F, T>(
+pub fn future_into_py_with_locals<F, T, P>(
     py: Python,
     locals: TaskLocals,
     fut: F,
 ) -> PyResult<Bound<PyAny>>
 where
     F: Future<Output = PyResult<T>> + Send + 'static,
-    T: IntoPyObject<'py>,
+    T: for<'py> IntoPyObject<'py, Target = P>,
+    P: AsRef<PyAny>,
 {
-    generic::future_into_py_with_locals::<AsyncStdRuntime, F, T>(py, locals, fut)
+    generic::future_into_py_with_locals::<AsyncStdRuntime, F, T, P>(py, locals, fut)
 }
 
 /// Convert a Rust Future into a Python awaitable
@@ -322,12 +323,13 @@ where
 ///     })
 /// }
 /// ```
-pub fn future_into_py<'py, F, T>(py: Python, fut: F) -> PyResult<Bound<PyAny>>
+pub fn future_into_py<F, T, P>(py: Python, fut: F) -> PyResult<Bound<PyAny>>
 where
     F: Future<Output = PyResult<T>> + Send + 'static,
-    T: IntoPyObject<'py>,
+    T: for<'py> IntoPyObject<'py, Target = P>,
+    P: AsRef<PyAny>,
 {
-    generic::future_into_py::<AsyncStdRuntime, _, T>(py, fut)
+    generic::future_into_py::<AsyncStdRuntime, _, T, P>(py, fut)
 }
 
 /// Convert a `!Send` Rust Future into a Python awaitable
@@ -393,16 +395,17 @@ where
     note = "Questionable whether these conversions have real-world utility (see https://github.com/awestlake87/pyo3-asyncio/issues/59#issuecomment-1008038497 and let me know if you disagree!)"
 )]
 #[allow(deprecated)]
-pub fn local_future_into_py_with_locals<'py, F, T>(
+pub fn local_future_into_py_with_locals<F, T, P>(
     py: Python,
     locals: TaskLocals,
     fut: F,
 ) -> PyResult<Bound<PyAny>>
 where
     F: Future<Output = PyResult<T>> + 'static,
-    T: IntoPyObject<'py>,
+    T: for<'py> IntoPyObject<'py, Target = P>,
+    P: AsRef<PyAny>,
 {
-    generic::local_future_into_py_with_locals::<AsyncStdRuntime, _, T>(py, locals, fut)
+    generic::local_future_into_py_with_locals::<AsyncStdRuntime, _, T, P>(py, locals, fut)
 }
 
 /// Convert a `!Send` Rust Future into a Python awaitable
@@ -463,12 +466,13 @@ where
     note = "Questionable whether these conversions have real-world utility (see https://github.com/awestlake87/pyo3-asyncio/issues/59#issuecomment-1008038497 and let me know if you disagree!)"
 )]
 #[allow(deprecated)]
-pub fn local_future_into_py<'py, F, T>(py: Python, fut: F) -> PyResult<Bound<PyAny>>
+pub fn local_future_into_py<F, T, P>(py: Python, fut: F) -> PyResult<Bound<PyAny>>
 where
     F: Future<Output = PyResult<T>> + 'static,
-    T: IntoPyObject<'py>,
+    T: for<'py> IntoPyObject<'py, Target = P>,
+    P: AsRef<PyAny>,
 {
-    generic::local_future_into_py::<AsyncStdRuntime, _, T>(py, fut)
+    generic::local_future_into_py::<AsyncStdRuntime, _, T, _>(py, fut)
 }
 
 /// Convert a Python `awaitable` into a Rust Future

--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -512,7 +512,7 @@ where
 ///     Python::with_gil(|py| {
 ///         pyo3_async_runtimes::async_std::into_future(
 ///             test_mod
-///                 .call_method1(py, "py_sleep", (seconds.into_py(py),))?
+///                 .call_method1(py, "py_sleep", (seconds.into_pyobject(py).unwrap(),))?
 ///                 .into_bound(py),
 ///         )
 ///     })?
@@ -539,6 +539,7 @@ pub fn into_future(
 /// ```
 /// use pyo3::prelude::*;
 /// use futures::{StreamExt, TryStreamExt};
+/// use std::ffi::CString;
 ///
 /// const TEST_MOD: &str = r#"
 /// import asyncio

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -457,7 +457,7 @@ fn set_result(
 ///     Python::with_gil(|py| {
 ///         pyo3_async_runtimes::generic::into_future::<MyCustomRuntime>(
 ///             test_mod
-///                 .call_method1(py, "py_sleep", (seconds.into_py(py),))?
+///                 .call_method1(py, "py_sleep", (seconds.into_pyobject(py).unwrap(),))?
 ///                 .into_bound(py),
 ///         )
 ///     })?

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -372,6 +372,7 @@ fn set_result(
 ///
 /// ```no_run
 /// # use std::{any::Any, pin::Pin, future::Future, task::{Context, Poll}, time::Duration};
+/// # use std::ffi::CString;
 /// #
 /// # use pyo3::prelude::*;
 /// #
@@ -443,11 +444,11 @@ fn set_result(
 /// async fn py_sleep(seconds: f32) -> PyResult<()> {
 ///     let test_mod = Python::with_gil(|py| -> PyResult<PyObject> {
 ///         Ok(
-///             PyModule::from_code_bound(
+///             PyModule::from_code(
 ///                 py,
-///                 PYTHON_CODE,
-///                 "test_into_future/test_mod.py",
-///                 "test_mod"
+///                 &CString::new(PYTHON_CODE).unwrap(),
+///                 &CString::new("test_into_future/test_mod.py").unwrap(),
+///                 &CString::new("test_mod").unwrap(),
 ///             )?
 ///             .into()
 ///         )
@@ -1266,6 +1267,7 @@ where
 ///
 /// use pyo3::prelude::*;
 /// use futures::{StreamExt, TryStreamExt};
+/// use std::ffi::CString;
 ///
 /// const TEST_MOD: &str = r#"
 /// import asyncio
@@ -1278,11 +1280,11 @@ where
 ///
 /// # async fn test_async_gen() -> PyResult<()> {
 /// let stream = Python::with_gil(|py| {
-///     let test_mod = PyModule::from_code_bound(
+///     let test_mod = PyModule::from_code(
 ///         py,
-///         TEST_MOD,
-///         "test_rust_coroutine/test_mod.py",
-///         "test_mod",
+///         &CString::new(TEST_MOD).unwrap(),
+///         &CString::new("test_rust_coroutine/test_mod.py").unwrap(),
+///         &CString::new("test_mod").unwrap(),
 ///     )?;
 ///
 ///     pyo3_async_runtimes::generic::into_stream_with_locals_v1::<MyCustomRuntime>(
@@ -1414,6 +1416,7 @@ where
 ///
 /// use pyo3::prelude::*;
 /// use futures::{StreamExt, TryStreamExt};
+/// use std::ffi::CString;
 ///
 /// const TEST_MOD: &str = r#"
 /// import asyncio
@@ -1426,11 +1429,11 @@ where
 ///
 /// # async fn test_async_gen() -> PyResult<()> {
 /// let stream = Python::with_gil(|py| {
-///     let test_mod = PyModule::from_code_bound(
+///     let test_mod = PyModule::from_code(
 ///         py,
-///         TEST_MOD,
-///         "test_rust_coroutine/test_mod.py",
-///         "test_mod",
+///         &CString::new(TEST_MOD).unwrap(),
+///         &CString::new("test_rust_coroutine/test_mod.py").unwrap(),
+///         &CString::new("test_mod").unwrap(),
 ///     )?;
 ///
 ///     pyo3_async_runtimes::generic::into_stream_v1::<MyCustomRuntime>(test_mod.call_method0("gen")?)
@@ -1622,6 +1625,7 @@ async def forward(gen, sender):
 ///
 /// use pyo3::prelude::*;
 /// use futures::{StreamExt, TryStreamExt};
+/// use std::ffi::CString;
 ///
 /// const TEST_MOD: &str = r#"
 /// import asyncio
@@ -1634,11 +1638,11 @@ async def forward(gen, sender):
 ///
 /// # async fn test_async_gen() -> PyResult<()> {
 /// let stream = Python::with_gil(|py| {
-///     let test_mod = PyModule::from_code_bound(
+///     let test_mod = PyModule::from_code(
 ///         py,
-///         TEST_MOD,
-///         "test_rust_coroutine/test_mod.py",
-///         "test_mod",
+///         &CString::new(TEST_MOD).unwrap(),
+///         &CString::new("test_rust_coroutine/test_mod.py").unwrap(),
+///         &CString::new("test_mod").unwrap(),
 ///     )?;
 ///
 ///     pyo3_async_runtimes::generic::into_stream_with_locals_v2::<MyCustomRuntime>(
@@ -1772,6 +1776,7 @@ where
 ///
 /// use pyo3::prelude::*;
 /// use futures::{StreamExt, TryStreamExt};
+/// use std::ffi::CString;
 ///
 /// const TEST_MOD: &str = r#"
 /// import asyncio
@@ -1784,11 +1789,11 @@ where
 ///
 /// # async fn test_async_gen() -> PyResult<()> {
 /// let stream = Python::with_gil(|py| {
-///     let test_mod = PyModule::from_code_bound(
+///     let test_mod = PyModule::from_code(
 ///         py,
-///         TEST_MOD,
-///         "test_rust_coroutine/test_mod.py",
-///         "test_mod",
+///         &CString::new(TEST_MOD).unwrap(),
+///         &CString::new("test_rust_coroutine/test_mod.py").unwrap(),
+///         &CString::new("test_mod").unwrap(),
 ///     )?;
 ///
 ///     pyo3_async_runtimes::generic::into_stream_v2::<MyCustomRuntime>(test_mod.call_method0("gen")?)

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -14,7 +14,6 @@
 //! ```
 
 use std::{
-    ffi::CString,
     future::Future,
     pin::Pin,
     sync::{Arc, Mutex},
@@ -1666,6 +1665,8 @@ pub fn into_stream_with_locals_v2<R>(
 where
     R: Runtime + ContextExt,
 {
+    use std::ffi::CString;
+
     static GLUE_MOD: OnceCell<PyObject> = OnceCell::new();
     let py = gen.py();
     let glue = GLUE_MOD

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -182,7 +182,7 @@ where
 /// # use pyo3::prelude::*;
 /// #
 /// # Python::with_gil(|py| -> PyResult<()> {
-/// # let event_loop = py.import_bound("asyncio")?.call_method0("new_event_loop")?;
+/// # let event_loop = py.import("asyncio")?.call_method0("new_event_loop")?;
 /// # #[cfg(feature = "tokio-runtime")]
 /// pyo3_async_runtimes::generic::run_until_complete::<MyCustomRuntime, _, _>(&event_loop, async move {
 ///     tokio::time::sleep(Duration::from_secs(1)).await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -577,7 +577,7 @@ impl PyEnsureFuture {
 }
 
 fn call_soon_threadsafe<'py>(
-    event_loop: &'py Bound<PyAny>,
+    event_loop: &Bound<'py, PyAny>,
     context: &Bound<PyAny>,
     args: impl IntoPyObject<'py, Target = PyTuple>,
 ) -> PyResult<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -605,6 +605,7 @@ fn call_soon_threadsafe<'py>(
 ///
 /// ```
 /// use std::time::Duration;
+/// use std::ffi::CString;
 ///
 /// use pyo3::prelude::*;
 ///
@@ -633,7 +634,7 @@ fn call_soon_threadsafe<'py>(
 ///         pyo3_async_runtimes::into_future_with_locals(
 ///             &pyo3_async_runtimes::tokio::get_current_locals(py)?,
 ///             test_mod
-///                 .call_method1(py, "py_sleep", (seconds.into_py(py),))?
+///                 .call_method1(py, "py_sleep", (seconds.into_pyobject(py).unwrap(),))?
 ///                 .into_bound(py),
 ///         )
 ///     })?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@
 //!             // event loop from earlier.
 //!             pyo3_async_runtimes::into_future_with_locals(
 //!                 &locals,
-//!                 py.import_bound("asyncio")?.call_method1("sleep", (1,))?
+//!                 py.import("asyncio")?.call_method1("sleep", (1,))?
 //!             )
 //!         })?;
 //!
@@ -169,7 +169,7 @@
 //!                 pyo3_async_runtimes::into_future_with_locals(
 //!                     // Now we can get the current locals through task-local data
 //!                     &pyo3_async_runtimes::tokio::get_current_locals(py)?,
-//!                     py.import_bound("asyncio")?.call_method1("sleep", (1,))?
+//!                     py.import("asyncio")?.call_method1("sleep", (1,))?
 //!                 )
 //!             })?;
 //!
@@ -244,7 +244,7 @@
 //!     pyo3_async_runtimes::tokio::future_into_py(py, async move {
 //!         let py_sleep = Python::with_gil(|py| {
 //!             pyo3_async_runtimes::tokio::into_future(
-//!                 py.import_bound("asyncio")?.call_method1("sleep", (1,))?
+//!                 py.import("asyncio")?.call_method1("sleep", (1,))?
 //!             )
 //!         })?;
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -619,11 +619,11 @@ fn call_soon_threadsafe<'py>(
 /// async fn py_sleep(seconds: f32) -> PyResult<()> {
 ///     let test_mod = Python::with_gil(|py| -> PyResult<PyObject> {
 ///         Ok(
-///             PyModule::from_code_bound(
+///             PyModule::from_code(
 ///                 py,
-///                 PYTHON_CODE,
-///                 "test_into_future/test_mod.py",
-///                 "test_mod"
+///                 &CString::new(PYTHON_CODE).unwrap(),
+///                 &CString::new("test_into_future/test_mod.py").unwrap(),
+///                 &CString::new("test_mod").unwrap(),
 ///             )?
 ///             .into()
 ///         )

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -64,7 +64,7 @@
 //! Also add the `testing` and `attributes` features to the `pyo3-async-runtimes` dependency and select your preferred runtime:
 //!
 //! ```toml
-//! pyo3-async-runtimes = { version = "0.22", features = ["testing", "attributes", "async-std-runtime"] }
+//! pyo3-async-runtimes = { version = "0.23", features = ["testing", "attributes", "async-std-runtime"] }
 //! ```
 //!
 //! At this point, you should be able to run the test via `cargo test`

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -315,16 +315,17 @@ where
 ///     )
 /// }
 /// ```
-pub fn future_into_py_with_locals<'py, F, T>(
+pub fn future_into_py_with_locals<F, T, P>(
     py: Python,
     locals: TaskLocals,
     fut: F,
 ) -> PyResult<Bound<PyAny>>
 where
     F: Future<Output = PyResult<T>> + Send + 'static,
-    T: IntoPyObject<'py>,
+    T: for<'py> IntoPyObject<'py, Target = P>,
+    P: AsRef<PyAny>,
 {
-    generic::future_into_py_with_locals::<TokioRuntime, F, T>(py, locals, fut)
+    generic::future_into_py_with_locals::<TokioRuntime, F, T, P>(py, locals, fut)
 }
 
 /// Convert a Rust Future into a Python awaitable
@@ -365,12 +366,13 @@ where
 ///     })
 /// }
 /// ```
-pub fn future_into_py<'py, F, T>(py: Python, fut: F) -> PyResult<Bound<PyAny>>
+pub fn future_into_py<F, T, P>(py: Python, fut: F) -> PyResult<Bound<PyAny>>
 where
     F: Future<Output = PyResult<T>> + Send + 'static,
-    T: IntoPyObject<'py>,
+    T: for<'py> IntoPyObject<'py, Target = P>,
+    P: AsRef<PyAny>,
 {
-    generic::future_into_py::<TokioRuntime, _, T>(py, fut)
+    generic::future_into_py::<TokioRuntime, _, T, _>(py, fut)
 }
 
 /// Convert a `!Send` Rust Future into a Python awaitable
@@ -452,16 +454,17 @@ where
     note = "Questionable whether these conversions have real-world utility (see https://github.com/awestlake87/pyo3-asyncio/issues/59#issuecomment-1008038497 and let me know if you disagree!)"
 )]
 #[allow(deprecated)]
-pub fn local_future_into_py_with_locals<'py, F, T>(
+pub fn local_future_into_py_with_locals<F, T, P>(
     py: Python,
     locals: TaskLocals,
     fut: F,
 ) -> PyResult<Bound<PyAny>>
 where
     F: Future<Output = PyResult<T>> + 'static,
-    T: IntoPyObject<'py>,
+    T: for<'py> IntoPyObject<'py, Target = P>,
+    P: AsRef<PyAny>,
 {
-    generic::local_future_into_py_with_locals::<TokioRuntime, _, T>(py, locals, fut)
+    generic::local_future_into_py_with_locals::<TokioRuntime, _, T, P>(py, locals, fut)
 }
 
 /// Convert a `!Send` Rust Future into a Python awaitable
@@ -537,12 +540,13 @@ where
     note = "Questionable whether these conversions have real-world utility (see https://github.com/awestlake87/pyo3-asyncio/issues/59#issuecomment-1008038497 and let me know if you disagree!)"
 )]
 #[allow(deprecated)]
-pub fn local_future_into_py<'py, F, T>(py: Python, fut: F) -> PyResult<Bound<PyAny>>
+pub fn local_future_into_py<F, T, P>(py: Python, fut: F) -> PyResult<Bound<PyAny>>
 where
     F: Future<Output = PyResult<T>> + 'static,
-    T: IntoPyObject<'py>,
+    T: for<'py> IntoPyObject<'py, Target = P>,
+    P: AsRef<PyAny>,
 {
-    generic::local_future_into_py::<TokioRuntime, _, T>(py, fut)
+    generic::local_future_into_py::<TokioRuntime, _, T, P>(py, fut)
 }
 
 /// Convert a Python `awaitable` into a Rust Future

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -9,7 +9,7 @@
 //!
 //! ```toml
 //! [dependencies.pyo3-async-runtimes]
-//! version = "0.22"
+//! version = "0.23"
 //! features = ["unstable-streams"]
 //! ```
 
@@ -315,14 +315,14 @@ where
 ///     )
 /// }
 /// ```
-pub fn future_into_py_with_locals<F, T>(
+pub fn future_into_py_with_locals<'py, F, T>(
     py: Python,
     locals: TaskLocals,
     fut: F,
 ) -> PyResult<Bound<PyAny>>
 where
     F: Future<Output = PyResult<T>> + Send + 'static,
-    T: IntoPy<PyObject>,
+    T: IntoPyObject<'py>,
 {
     generic::future_into_py_with_locals::<TokioRuntime, F, T>(py, locals, fut)
 }
@@ -365,10 +365,10 @@ where
 ///     })
 /// }
 /// ```
-pub fn future_into_py<F, T>(py: Python, fut: F) -> PyResult<Bound<PyAny>>
+pub fn future_into_py<'py, F, T>(py: Python, fut: F) -> PyResult<Bound<PyAny>>
 where
     F: Future<Output = PyResult<T>> + Send + 'static,
-    T: IntoPy<PyObject>,
+    T: IntoPyObject<'py>,
 {
     generic::future_into_py::<TokioRuntime, _, T>(py, fut)
 }
@@ -452,14 +452,14 @@ where
     note = "Questionable whether these conversions have real-world utility (see https://github.com/awestlake87/pyo3-asyncio/issues/59#issuecomment-1008038497 and let me know if you disagree!)"
 )]
 #[allow(deprecated)]
-pub fn local_future_into_py_with_locals<F, T>(
+pub fn local_future_into_py_with_locals<'py, F, T>(
     py: Python,
     locals: TaskLocals,
     fut: F,
 ) -> PyResult<Bound<PyAny>>
 where
     F: Future<Output = PyResult<T>> + 'static,
-    T: IntoPy<PyObject>,
+    T: IntoPyObject<'py>,
 {
     generic::local_future_into_py_with_locals::<TokioRuntime, _, T>(py, locals, fut)
 }
@@ -537,10 +537,10 @@ where
     note = "Questionable whether these conversions have real-world utility (see https://github.com/awestlake87/pyo3-asyncio/issues/59#issuecomment-1008038497 and let me know if you disagree!)"
 )]
 #[allow(deprecated)]
-pub fn local_future_into_py<F, T>(py: Python, fut: F) -> PyResult<Bound<PyAny>>
+pub fn local_future_into_py<'py, F, T>(py: Python, fut: F) -> PyResult<Bound<PyAny>>
 where
     F: Future<Output = PyResult<T>> + 'static,
-    T: IntoPy<PyObject>,
+    T: IntoPyObject<'py>,
 {
     generic::local_future_into_py::<TokioRuntime, _, T>(py, fut)
 }

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -222,7 +222,7 @@ fn multi_thread() -> Builder {
 /// #
 /// # pyo3::prepare_freethreaded_python();
 /// # Python::with_gil(|py| -> PyResult<()> {
-/// # let event_loop = py.import_bound("asyncio")?.call_method0("new_event_loop")?;
+/// # let event_loop = py.import("asyncio")?.call_method0("new_event_loop")?;
 /// pyo3_async_runtimes::tokio::run_until_complete(event_loop, async move {
 ///     tokio::time::sleep(Duration::from_secs(1)).await;
 ///     Ok(())

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -559,6 +559,7 @@ where
 ///
 /// ```
 /// use std::time::Duration;
+/// use std::ffi::CString;
 ///
 /// use pyo3::prelude::*;
 ///
@@ -572,11 +573,11 @@ where
 /// async fn py_sleep(seconds: f32) -> PyResult<()> {
 ///     let test_mod = Python::with_gil(|py| -> PyResult<PyObject> {
 ///         Ok(
-///             PyModule::from_code_bound(
+///             PyModule::from_code(
 ///                 py,
-///                 PYTHON_CODE,
-///                 "test_into_future/test_mod.py",
-///                 "test_mod"
+///                 &CString::new(PYTHON_CODE).unwrap(),
+///                 &CString::new("test_into_future/test_mod.py").unwrap(),
+///                 &CString::new("test_mod").unwrap(),
 ///             )?
 ///             .into()
 ///         )
@@ -613,6 +614,7 @@ pub fn into_future(
 /// ```
 /// use pyo3::prelude::*;
 /// use futures::{StreamExt, TryStreamExt};
+/// use std::ffi::CString;
 ///
 /// const TEST_MOD: &str = r#"
 /// import asyncio
@@ -627,11 +629,11 @@ pub fn into_future(
 /// # #[pyo3_async_runtimes::tokio::main]
 /// # async fn main() -> PyResult<()> {
 /// let stream = Python::with_gil(|py| {
-///     let test_mod = PyModule::from_code_bound(
+///     let test_mod = PyModule::from_code(
 ///         py,
-///         TEST_MOD,
-///         "test_rust_coroutine/test_mod.py",
-///         "test_mod",
+///         &CString::new(TEST_MOD).unwrap(),
+///         &CString::new("test_rust_coroutine/test_mod.py").unwrap(),
+///         &CString::new("test_mod").unwrap(),
 ///     )?;
 ///
 ///     pyo3_async_runtimes::tokio::into_stream_with_locals_v1(
@@ -673,6 +675,7 @@ pub fn into_stream_with_locals_v1(
 /// ```
 /// use pyo3::prelude::*;
 /// use futures::{StreamExt, TryStreamExt};
+/// use std::ffi::CString;
 ///
 /// const TEST_MOD: &str = r#"
 /// import asyncio
@@ -687,11 +690,11 @@ pub fn into_stream_with_locals_v1(
 /// # #[pyo3_async_runtimes::tokio::main]
 /// # async fn main() -> PyResult<()> {
 /// let stream = Python::with_gil(|py| {
-///     let test_mod = PyModule::from_code_bound(
+///     let test_mod = PyModule::from_code(
 ///         py,
-///         TEST_MOD,
-///         "test_rust_coroutine/test_mod.py",
-///         "test_mod",
+///         &CString::new(TEST_MOD).unwrap(),
+///         &CString::new("test_rust_coroutine/test_mod.py").unwrap(),
+///         &CString::new("test_mod").unwrap(),
 ///     )?;
 ///
 ///     pyo3_async_runtimes::tokio::into_stream_v1(test_mod.call_method0("gen")?)
@@ -730,6 +733,7 @@ pub fn into_stream_v1(
 /// ```
 /// use pyo3::prelude::*;
 /// use futures::{StreamExt, TryStreamExt};
+/// use std::ffi::CString;
 ///
 /// const TEST_MOD: &str = r#"
 /// import asyncio
@@ -744,11 +748,11 @@ pub fn into_stream_v1(
 /// # #[pyo3_async_runtimes::tokio::main]
 /// # async fn main() -> PyResult<()> {
 /// let stream = Python::with_gil(|py| {
-///     let test_mod = PyModule::from_code_bound(
+///     let test_mod = PyModule::from_code(
 ///         py,
-///         TEST_MOD,
-///         "test_rust_coroutine/test_mod.py",
-///         "test_mod",
+///         &CString::new(TEST_MOD).unwrap(),
+///         &CString::new("test_rust_coroutine/test_mod.py").unwrap(),
+///         &CString::new("test_mod").unwrap(),
 ///     )?;
 ///
 ///     pyo3_async_runtimes::tokio::into_stream_with_locals_v2(
@@ -790,6 +794,7 @@ pub fn into_stream_with_locals_v2(
 /// ```
 /// use pyo3::prelude::*;
 /// use futures::{StreamExt, TryStreamExt};
+/// use std::ffi::CString;
 ///
 /// const TEST_MOD: &str = r#"
 /// import asyncio
@@ -804,11 +809,11 @@ pub fn into_stream_with_locals_v2(
 /// # #[pyo3_async_runtimes::tokio::main]
 /// # async fn main() -> PyResult<()> {
 /// let stream = Python::with_gil(|py| {
-///     let test_mod = PyModule::from_code_bound(
+///     let test_mod = PyModule::from_code(
 ///         py,
-///         TEST_MOD,
-///         "test_rust_coroutine/test_mod.py",
-///         "test_mod",
+///         &CString::new(TEST_MOD).unwrap(),
+///         &CString::new("test_rust_coroutine/test_mod.py").unwrap(),
+///         &CString::new("test_mod").unwrap(),
 ///     )?;
 ///
 ///     pyo3_async_runtimes::tokio::into_stream_v2(test_mod.call_method0("gen")?)

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -315,17 +315,16 @@ where
 ///     )
 /// }
 /// ```
-pub fn future_into_py_with_locals<F, T, P>(
+pub fn future_into_py_with_locals<F, T>(
     py: Python,
     locals: TaskLocals,
     fut: F,
 ) -> PyResult<Bound<PyAny>>
 where
     F: Future<Output = PyResult<T>> + Send + 'static,
-    T: for<'py> IntoPyObject<'py, Target = P>,
-    P: AsRef<PyAny>,
+    T: for<'py> IntoPyObject<'py>,
 {
-    generic::future_into_py_with_locals::<TokioRuntime, F, T, P>(py, locals, fut)
+    generic::future_into_py_with_locals::<TokioRuntime, F, T>(py, locals, fut)
 }
 
 /// Convert a Rust Future into a Python awaitable
@@ -366,13 +365,12 @@ where
 ///     })
 /// }
 /// ```
-pub fn future_into_py<F, T, P>(py: Python, fut: F) -> PyResult<Bound<PyAny>>
+pub fn future_into_py<F, T>(py: Python, fut: F) -> PyResult<Bound<PyAny>>
 where
     F: Future<Output = PyResult<T>> + Send + 'static,
-    T: for<'py> IntoPyObject<'py, Target = P>,
-    P: AsRef<PyAny>,
+    T: for<'py> IntoPyObject<'py>,
 {
-    generic::future_into_py::<TokioRuntime, _, T, _>(py, fut)
+    generic::future_into_py::<TokioRuntime, _, T>(py, fut)
 }
 
 /// Convert a `!Send` Rust Future into a Python awaitable
@@ -454,17 +452,16 @@ where
     note = "Questionable whether these conversions have real-world utility (see https://github.com/awestlake87/pyo3-asyncio/issues/59#issuecomment-1008038497 and let me know if you disagree!)"
 )]
 #[allow(deprecated)]
-pub fn local_future_into_py_with_locals<F, T, P>(
+pub fn local_future_into_py_with_locals<F, T>(
     py: Python,
     locals: TaskLocals,
     fut: F,
 ) -> PyResult<Bound<PyAny>>
 where
     F: Future<Output = PyResult<T>> + 'static,
-    T: for<'py> IntoPyObject<'py, Target = P>,
-    P: AsRef<PyAny>,
+    T: for<'py> IntoPyObject<'py>,
 {
-    generic::local_future_into_py_with_locals::<TokioRuntime, _, T, P>(py, locals, fut)
+    generic::local_future_into_py_with_locals::<TokioRuntime, _, T>(py, locals, fut)
 }
 
 /// Convert a `!Send` Rust Future into a Python awaitable
@@ -540,13 +537,12 @@ where
     note = "Questionable whether these conversions have real-world utility (see https://github.com/awestlake87/pyo3-asyncio/issues/59#issuecomment-1008038497 and let me know if you disagree!)"
 )]
 #[allow(deprecated)]
-pub fn local_future_into_py<F, T, P>(py: Python, fut: F) -> PyResult<Bound<PyAny>>
+pub fn local_future_into_py<F, T>(py: Python, fut: F) -> PyResult<Bound<PyAny>>
 where
     F: Future<Output = PyResult<T>> + 'static,
-    T: for<'py> IntoPyObject<'py, Target = P>,
-    P: AsRef<PyAny>,
+    T: for<'py> IntoPyObject<'py>,
 {
-    generic::local_future_into_py::<TokioRuntime, _, T, P>(py, fut)
+    generic::local_future_into_py::<TokioRuntime, _, T>(py, fut)
 }
 
 /// Convert a Python `awaitable` into a Rust Future

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -586,7 +586,7 @@ where
 ///     Python::with_gil(|py| {
 ///         pyo3_async_runtimes::tokio::into_future(
 ///             test_mod
-///                 .call_method1(py, "py_sleep", (seconds.into_py(py),))?
+///                 .call_method1(py, "py_sleep", (seconds.into_pyobject(py).unwrap(),))?
 ///                 .into_bound(py),
 ///         )
 ///     })?


### PR DESCRIPTION
### Change list 

- Bump pyo3-async-runtimes version in Cargo.toml and documentation to 0.23
- Bump pyo3 dependency version to 0.23
- Switched to new `IntoPyObject` trait, with a couple compilation errors still that I'm not sure how to fix.
- Fixed lints to remove `_bound` suffix
