### PR TITLE
Update pyo3 requirement from 0.23 to 0.24

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,11 +120,11 @@ futures = "0.3"
 inventory = { version = "0.3", optional = true }
 once_cell = "1.14"
 pin-project-lite = "0.2"
-pyo3 = "0.23"
-pyo3-async-runtimes-macros = { path = "pyo3-async-runtimes-macros", version = "=0.23.0", optional = true }
+pyo3 = "0.24.0"
+pyo3-async-runtimes-macros = { path = "pyo3-async-runtimes-macros", version = "=0.24.0", optional = true }
 
 [dev-dependencies]
-pyo3 = { version = "0.23", features = ["macros"] }
+pyo3 = { version = "0.24.0", features = ["macros"] }
 
 [dependencies.async-std]
 version = "1.12"

--- a/pyo3-async-runtimes-macros/Cargo.toml
+++ b/pyo3-async-runtimes-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pyo3-async-runtimes-macros"
 description = "Proc Macro Attributes for `pyo3-async-runtimes`"
-version = "0.23.0"
+version = "0.24.0"
 authors = [
     "Andrew J Westlake <awestlake87@yahoo.com>",
     "David Hewitt <mail@davidhewitt.dev>",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -579,7 +579,7 @@ impl PyEnsureFuture {
 fn call_soon_threadsafe<'py>(
     event_loop: &Bound<'py, PyAny>,
     context: &Bound<PyAny>,
-    args: impl IntoPyObject<'py, Target = PyTuple>,
+    args: impl IntoPyObject<'py, Target = PyTuple> + pyo3::call::PyCallArgs<'py>,
 ) -> PyResult<()> {
     let py = event_loop.py();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -398,10 +398,7 @@ use std::future::Future;
 
 use futures::channel::oneshot;
 use once_cell::sync::OnceCell;
-use pyo3::{
-    prelude::*,
-    types::{PyDict, PyTuple},
-};
+use pyo3::{prelude::*, types::PyDict};
 
 static ASYNCIO: OnceCell<PyObject> = OnceCell::new();
 static CONTEXTVARS: OnceCell<PyObject> = OnceCell::new();
@@ -579,7 +576,7 @@ impl PyEnsureFuture {
 fn call_soon_threadsafe<'py>(
     event_loop: &Bound<'py, PyAny>,
     context: &Bound<PyAny>,
-    args: impl IntoPyObject<'py, Target = PyTuple> + pyo3::call::PyCallArgs<'py>,
+    args: impl pyo3::call::PyCallArgs<'py>,
 ) -> PyResult<()> {
     let py = event_loop.py();
 


### PR DESCRIPTION
This pull request includes several updates to dependencies and minor improvements to the codebase. The most important changes include updating the `pyo3` crate version, modifying the `pyo3-async-runtimes-macros` crate version, and enhancing the `call_soon_threadsafe` function in `src/lib.rs`.

Dependency updates:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L123-R127): Updated `pyo3` crate version from `0.23` to `0.24.0` and `pyo3-async-runtimes-macros` crate version to `0.24.0`.
* [`pyo3-async-runtimes-macros/Cargo.toml`](diffhunk://#diff-baef79f780802058a32ae85eb09e26d96c19b78c8089411d48b1a8807356a40dL4-R4): Updated the version of `pyo3-async-runtimes-macros` crate from `0.23.0` to `0.24.0`.

Code improvements:

* [`src/lib.rs`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L582-R582): Enhanced the `call_soon_threadsafe` function by adding the `pyo3::call::PyCallArgs` trait to the `args` parameter.