### PR TITLE
remove test requirement from publish command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,6 @@ test-feature-powerset: lint
 	cargo install cargo-hack
 	cargo hack test --feature-powerset
 
-publish: test-feature-powerset
+publish:
 	cargo publish --package=pyo3-async-runtimes-macros
 	cargo publish


### PR DESCRIPTION
In PyO3 and `rust-numpy` we haven't been running the test as part of the publish flow; the assumption being that we only tag the release when we're happy with the state of `main` anyway.

Once this is merged, we should be able to recreate the github release and push ok 👍 