### PR TITLE
Prepare for pyo3 0.26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,12 +126,6 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.platform.rust-target }}
 
-      - if: ${{ matrix.msrv == 'MSRV' }}
-        name: Set MSRV dependencies
-        run: |
-          cargo add tokio@=1.38.1
-          cargo update -p once_cell --precise 1.20.3
-
       - name: Build (no features)
         run: cargo build --no-default-features --verbose --target ${{ matrix.platform.rust-target }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
           ]
         include:
           # Test minimal supported Rust version
-          - rust: 1.63.0
+          - rust: 1.74.0
             python-version: "3.13"
             platform:
               {

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pyo3-async-runtimes"
 description = "PyO3 bridges from Rust runtimes to Python's Asyncio library"
-version = "0.25.0"
+version = "0.26.0"
 authors = [
     "Andrew J Westlake <awestlake87@yahoo.com>",
     "David Hewitt <mail@davidhewitt.dev>",
@@ -120,11 +120,13 @@ futures = "0.3"
 inventory = { version = "0.3", optional = true }
 once_cell = "1.14"
 pin-project-lite = "0.2"
-pyo3 = "0.25"
-pyo3-async-runtimes-macros = { path = "pyo3-async-runtimes-macros", version = "=0.25.0", optional = true }
+pyo3 = { git = "https://github.com/PyO3/pyo3", rev = "v0.26.0", version = "0.26" }
+pyo3-async-runtimes-macros = { path = "pyo3-async-runtimes-macros", version = "=0.26.0", optional = true }
 
 [dev-dependencies]
-pyo3 = { version = "0.25", features = ["macros"] }
+pyo3 = { git = "https://github.com/PyO3/pyo3", rev = "v0.26.0", version = "0.26", features = [
+    "macros",
+] }
 
 [dependencies.async-std]
 version = "1.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,13 +120,11 @@ futures = "0.3"
 inventory = { version = "0.3", optional = true }
 once_cell = "1.14"
 pin-project-lite = "0.2"
-pyo3 = { git = "https://github.com/PyO3/pyo3", rev = "v0.26.0", version = "0.26" }
+pyo3 = "0.26"
 pyo3-async-runtimes-macros = { path = "pyo3-async-runtimes-macros", version = "=0.26.0", optional = true }
 
 [dev-dependencies]
-pyo3 = { git = "https://github.com/PyO3/pyo3", rev = "v0.26.0", version = "0.26", features = [
-    "macros",
-] }
+pyo3 = { version = "0.26", features = ["macros"] }
 
 [dependencies.async-std]
 version = "1.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["api-bindings", "development-tools::ffi"]
 license = "Apache-2.0"
 exclude = ["/.gitignore", "/codecov.yml", "/Makefile"]
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.74"
 
 [workspace]
 members = ["pyo3-async-runtimes-macros"]

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ Here we initialize the runtime, import Python's `asyncio` library and run the gi
 ```toml
 # Cargo.toml dependencies
 [dependencies]
-pyo3 = { version = "0.25" }
-pyo3-async-runtimes = { version = "0.25", features = ["attributes", "async-std-runtime"] }
+pyo3 = { version = "0.26" }
+pyo3-async-runtimes = { version = "0.26", features = ["attributes", "async-std-runtime"] }
 async-std = "1.13"
 ```
 
@@ -80,8 +80,8 @@ attribute.
 ```toml
 # Cargo.toml dependencies
 [dependencies]
-pyo3 = { version = "0.25" }
-pyo3-async-runtimes = { version = "0.25", features = ["attributes", "tokio-runtime"] }
+pyo3 = { version = "0.26" }
+pyo3-async-runtimes = { version = "0.26", features = ["attributes", "tokio-runtime"] }
 tokio = "1.40"
 ```
 
@@ -126,8 +126,8 @@ For `async-std`:
 
 ```toml
 [dependencies]
-pyo3 = { version = "0.25", features = ["extension-module"] }
-pyo3-async-runtimes = { version = "0.25", features = ["async-std-runtime"] }
+pyo3 = { version = "0.26", features = ["extension-module"] }
+pyo3-async-runtimes = { version = "0.26", features = ["async-std-runtime"] }
 async-std = "1.13"
 ```
 
@@ -135,8 +135,8 @@ For `tokio`:
 
 ```toml
 [dependencies]
-pyo3 = { version = "0.25", features = ["extension-module"] }
-pyo3-async-runtimes = { version = "0.25", features = ["tokio-runtime"] }
+pyo3 = { version = "0.26", features = ["extension-module"] }
+pyo3-async-runtimes = { version = "0.26", features = ["tokio-runtime"] }
 tokio = "1.40"
 ```
 
@@ -430,8 +430,8 @@ name = "my_async_module"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.25", features = ["extension-module"] }
-pyo3-async-runtimes = { version = "0.25", features = ["tokio-runtime"] }
+pyo3 = { version = "0.26", features = ["extension-module"] }
+pyo3-async-runtimes = { version = "0.26", features = ["tokio-runtime"] }
 async-std = "1.13"
 tokio = "1.40"
 ```
@@ -490,8 +490,8 @@ event loop before we can install the `uvloop` policy.
 ```toml
 [dependencies]
 async-std = "1.13"
-pyo3 = "0.25"
-pyo3-async-runtimes = { version = "0.25", features = ["async-std-runtime"] }
+pyo3 = "0.26"
+pyo3-async-runtimes = { version = "0.26", features = ["async-std-runtime"] }
 ```
 
 ```rust no_run

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ async fn main() -> PyResult<()> {
     let fut = Python::attach(|py| {
         let asyncio = py.import("asyncio")?;
         // convert asyncio.sleep into a Rust Future
-        pyo3_async_runtimes::async_std::into_future(asyncio.call_method1("sleep", (1.into_pyobject(py).unwrap(),))?)
+        pyo3_async_runtimes::async_std::into_future(asyncio.call_method1("sleep", (1,))?)
     })?;
 
     fut.await?;
@@ -95,7 +95,7 @@ async fn main() -> PyResult<()> {
     let fut = Python::attach(|py| {
         let asyncio = py.import("asyncio")?;
         // convert asyncio.sleep into a Rust Future
-        pyo3_async_runtimes::tokio::into_future(asyncio.call_method1("sleep", (1.into_pyobject(py).unwrap(),))?)
+        pyo3_async_runtimes::tokio::into_future(asyncio.call_method1("sleep", (1,))?)
     })?;
 
     fut.await?;
@@ -359,7 +359,7 @@ async fn main() -> PyResult<()> {
 
         // convert asyncio.sleep into a Rust Future
         pyo3_async_runtimes::async_std::into_future(
-            asyncio.call_method1("sleep", (1.into_pyobject(py).unwrap(),))?
+            asyncio.call_method1("sleep", (1,))?
         )
     })?;
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ use pyo3::prelude::*;
 
 #[pyo3_async_runtimes::async_std::main]
 async fn main() -> PyResult<()> {
-    let fut = Python::with_gil(|py| {
+    let fut = Python::attach(|py| {
         let asyncio = py.import("asyncio")?;
         // convert asyncio.sleep into a Rust Future
         pyo3_async_runtimes::async_std::into_future(asyncio.call_method1("sleep", (1.into_pyobject(py).unwrap(),))?)
@@ -92,7 +92,7 @@ use pyo3::prelude::*;
 
 #[pyo3_async_runtimes::tokio::main]
 async fn main() -> PyResult<()> {
-    let fut = Python::with_gil(|py| {
+    let fut = Python::attach(|py| {
         let asyncio = py.import("asyncio")?;
         // convert asyncio.sleep into a Rust Future
         pyo3_async_runtimes::tokio::into_future(asyncio.call_method1("sleep", (1.into_pyobject(py).unwrap(),))?)
@@ -234,7 +234,7 @@ use pyo3::prelude::*;
 
 #[pyo3_async_runtimes::tokio::main]
 async fn main() -> PyResult<()> {
-    let future = Python::with_gil(|py| -> PyResult<_> {
+    let future = Python::attach(|py| -> PyResult<_> {
         // import the module containing the py_sleep function
         let example = py.import("example")?;
 
@@ -354,7 +354,7 @@ use pyo3::prelude::*;
 async fn main() -> PyResult<()> {
     // PyO3 is initialized - Ready to go
 
-    let fut = Python::with_gil(|py| -> PyResult<_> {
+    let fut = Python::attach(|py| -> PyResult<_> {
         let asyncio = py.import("asyncio")?;
 
         // convert asyncio.sleep into a Rust Future
@@ -500,18 +500,18 @@ pyo3-async-runtimes = { version = "0.26", features = ["async-std-runtime"] }
 use pyo3::{prelude::*, types::PyType};
 
 fn main() -> PyResult<()> {
-    pyo3::prepare_freethreaded_python();
+    Python::initialize();
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let uvloop = py.import("uvloop")?;
         uvloop.call_method0("install")?;
 
         // store a reference for the assertion
-        let uvloop = PyObject::from(uvloop);
+        let uvloop: Py<PyAny> = uvloop.into();
 
         pyo3_async_runtimes::async_std::run(py, async move {
             // verify that we are on a uvloop.Loop
-            Python::with_gil(|py| -> PyResult<()> {
+            Python::attach(|py| -> PyResult<()> {
                 assert!(uvloop
                     .bind(py)
                     .getattr("Loop")?

--- a/examples/async_std.rs
+++ b/examples/async_std.rs
@@ -6,9 +6,7 @@ async fn main() -> PyResult<()> {
         let asyncio = py.import("asyncio")?;
 
         // convert asyncio.sleep into a Rust Future
-        pyo3_async_runtimes::async_std::into_future(
-            asyncio.call_method1("sleep", (1.into_pyobject(py).unwrap(),))?,
-        )
+        pyo3_async_runtimes::async_std::into_future(asyncio.call_method1("sleep", (1,))?)
     })?;
 
     println!("sleeping for 1s");

--- a/examples/async_std.rs
+++ b/examples/async_std.rs
@@ -2,7 +2,7 @@ use pyo3::prelude::*;
 
 #[pyo3_async_runtimes::async_std::main]
 async fn main() -> PyResult<()> {
-    let fut = Python::with_gil(|py| {
+    let fut = Python::attach(|py| {
         let asyncio = py.import("asyncio")?;
 
         // convert asyncio.sleep into a Rust Future

--- a/examples/tokio.rs
+++ b/examples/tokio.rs
@@ -2,7 +2,7 @@ use pyo3::prelude::*;
 
 #[pyo3_async_runtimes::tokio::main]
 async fn main() -> PyResult<()> {
-    let fut = Python::with_gil(|py| {
+    let fut = Python::attach(|py| {
         let asyncio = py.import("asyncio")?;
 
         // convert asyncio.sleep into a Rust Future

--- a/examples/tokio.rs
+++ b/examples/tokio.rs
@@ -6,9 +6,7 @@ async fn main() -> PyResult<()> {
         let asyncio = py.import("asyncio")?;
 
         // convert asyncio.sleep into a Rust Future
-        pyo3_async_runtimes::tokio::into_future(
-            asyncio.call_method1("sleep", (1.into_pyobject(py).unwrap(),))?,
-        )
+        pyo3_async_runtimes::tokio::into_future(asyncio.call_method1("sleep", (1,))?)
     })?;
 
     println!("sleeping for 1s");

--- a/examples/tokio_current_thread.rs
+++ b/examples/tokio_current_thread.rs
@@ -6,9 +6,7 @@ async fn main() -> PyResult<()> {
         let asyncio = py.import("asyncio")?;
 
         // convert asyncio.sleep into a Rust Future
-        pyo3_async_runtimes::tokio::into_future(
-            asyncio.call_method1("sleep", (1.into_pyobject(py).unwrap(),))?,
-        )
+        pyo3_async_runtimes::tokio::into_future(asyncio.call_method1("sleep", (1,))?)
     })?;
 
     println!("sleeping for 1s");

--- a/examples/tokio_current_thread.rs
+++ b/examples/tokio_current_thread.rs
@@ -2,7 +2,7 @@ use pyo3::prelude::*;
 
 #[pyo3_async_runtimes::tokio::main(flavor = "current_thread")]
 async fn main() -> PyResult<()> {
-    let fut = Python::with_gil(|py| {
+    let fut = Python::attach(|py| {
         let asyncio = py.import("asyncio")?;
 
         // convert asyncio.sleep into a Rust Future

--- a/examples/tokio_multi_thread.rs
+++ b/examples/tokio_multi_thread.rs
@@ -6,9 +6,7 @@ async fn main() -> PyResult<()> {
         let asyncio = py.import("asyncio")?;
 
         // convert asyncio.sleep into a Rust Future
-        pyo3_async_runtimes::tokio::into_future(
-            asyncio.call_method1("sleep", (1.into_pyobject(py).unwrap(),))?,
-        )
+        pyo3_async_runtimes::tokio::into_future(asyncio.call_method1("sleep", (1,))?)
     })?;
 
     println!("sleeping for 1s");

--- a/examples/tokio_multi_thread.rs
+++ b/examples/tokio_multi_thread.rs
@@ -2,7 +2,7 @@ use pyo3::prelude::*;
 
 #[pyo3_async_runtimes::tokio::main(flavor = "multi_thread", worker_threads = 10)]
 async fn main() -> PyResult<()> {
-    let fut = Python::with_gil(|py| {
+    let fut = Python::attach(|py| {
         let asyncio = py.import("asyncio")?;
 
         // convert asyncio.sleep into a Rust Future

--- a/pyo3-async-runtimes-macros/Cargo.toml
+++ b/pyo3-async-runtimes-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pyo3-async-runtimes-macros"
 description = "Proc Macro Attributes for `pyo3-async-runtimes`"
-version = "0.25.0"
+version = "0.26.0"
 authors = [
     "Andrew J Westlake <awestlake87@yahoo.com>",
     "David Hewitt <mail@davidhewitt.dev>",

--- a/pyo3-async-runtimes-macros/src/lib.rs
+++ b/pyo3-async-runtimes-macros/src/lib.rs
@@ -49,9 +49,9 @@ pub fn async_std_main(_attr: TokenStream, item: TokenStream) -> TokenStream {
                 #body
             }
 
-            pyo3::prepare_freethreaded_python();
+            Python::initialize();
 
-            pyo3::Python::with_gil(|py| {
+            pyo3::Python::attach(|py| {
                 pyo3_async_runtimes::async_std::run(py, main())
                     .map_err(|e| {
                         e.print_and_set_sys_last_vars(py);
@@ -129,7 +129,7 @@ pub fn tokio_main(args: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// // blocking test functions can optionally accept an event_loop parameter
 /// #[pyo3_async_runtimes::async_std::test]
-/// fn test_blocking_sleep_with_event_loop(event_loop: PyObject) -> PyResult<()> {
+/// fn test_blocking_sleep_with_event_loop(event_loop: Py<PyAny>) -> PyResult<()> {
 ///     thread::sleep(Duration::from_secs(1));
 ///     Ok(())
 /// }
@@ -154,7 +154,7 @@ pub fn async_std_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
             }
         } else {
             quote! {
-                let event_loop = Python::with_gil(|py| {
+                let event_loop = Python::attach(|py| {
                     pyo3_async_runtimes::async_std::get_current_loop(py).unwrap().into()
                 });
                 Box::pin(pyo3_async_runtimes::async_std::re_exports::spawn_blocking(move || {
@@ -226,7 +226,7 @@ pub fn async_std_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// // blocking test functions can optionally accept an event_loop parameter
 /// #[pyo3_async_runtimes::tokio::test]
-/// fn test_blocking_sleep_with_event_loop(event_loop: PyObject) -> PyResult<()> {
+/// fn test_blocking_sleep_with_event_loop(event_loop: Py<PyAny>) -> PyResult<()> {
 ///     thread::sleep(Duration::from_secs(1));
 ///     Ok(())
 /// }
@@ -265,7 +265,7 @@ pub fn tokio_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
             }
         } else {
             quote! {
-                let event_loop = Python::with_gil(|py| {
+                let event_loop = Python::attach(|py| {
                     pyo3_async_runtimes::tokio::get_current_loop(py).unwrap().into()
                 });
                 Box::pin(async move {

--- a/pyo3-async-runtimes-macros/src/lib.rs
+++ b/pyo3-async-runtimes-macros/src/lib.rs
@@ -49,7 +49,7 @@ pub fn async_std_main(_attr: TokenStream, item: TokenStream) -> TokenStream {
                 #body
             }
 
-            Python::initialize();
+            pyo3::Python::initialize();
 
             pyo3::Python::attach(|py| {
                 pyo3_async_runtimes::async_std::run(py, main())
@@ -154,7 +154,7 @@ pub fn async_std_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
             }
         } else {
             quote! {
-                let event_loop = Python::attach(|py| {
+                let event_loop = pyo3::Python::attach(|py| {
                     pyo3_async_runtimes::async_std::get_current_loop(py).unwrap().into()
                 });
                 Box::pin(pyo3_async_runtimes::async_std::re_exports::spawn_blocking(move || {
@@ -265,7 +265,7 @@ pub fn tokio_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
             }
         } else {
             quote! {
-                let event_loop = Python::attach(|py| {
+                let event_loop = pyo3::Python::attach(|py| {
                     pyo3_async_runtimes::tokio::get_current_loop(py).unwrap().into()
                 });
                 Box::pin(async move {

--- a/pyo3-async-runtimes-macros/src/tokio.rs
+++ b/pyo3-async-runtimes-macros/src/tokio.rs
@@ -268,7 +268,7 @@ fn parse_knobs(
                 #body
             }
 
-            pyo3::prepare_freethreaded_python();
+            Python::initialize();
 
             let mut builder = #builder;
             #builder_init;
@@ -277,7 +277,7 @@ fn parse_knobs(
 
             #rt_init
 
-            pyo3::Python::with_gil(|py| {
+            pyo3::Python::attach(|py| {
                 pyo3_async_runtimes::tokio::run(py, main())
                     .map_err(|e| {
                         e.print_and_set_sys_last_vars(py);

--- a/pyo3-async-runtimes-macros/src/tokio.rs
+++ b/pyo3-async-runtimes-macros/src/tokio.rs
@@ -268,7 +268,7 @@ fn parse_knobs(
                 #body
             }
 
-            Python::initialize();
+            pyo3::Python::initialize();
 
             let mut builder = #builder;
             #builder_init;

--- a/pytests/common/mod.rs
+++ b/pytests/common/mod.rs
@@ -14,8 +14,8 @@ async def sleep_for_1s(sleep_for):
     await sleep_for(1)
 "#;
 
-pub(super) async fn test_into_future(event_loop: PyObject) -> PyResult<()> {
-    let fut = Python::with_gil(|py| {
+pub(super) async fn test_into_future(event_loop: Py<PyAny>) -> PyResult<()> {
+    let fut = Python::attach(|py| {
         let test_mod = PyModule::from_code(
             py,
             &CString::new(TEST_MOD).unwrap(),
@@ -39,8 +39,8 @@ pub(super) fn test_blocking_sleep() -> PyResult<()> {
     Ok(())
 }
 
-pub(super) async fn test_other_awaitables(event_loop: PyObject) -> PyResult<()> {
-    let fut = Python::with_gil(|py| {
+pub(super) async fn test_other_awaitables(event_loop: Py<PyAny>) -> PyResult<()> {
+    let fut = Python::attach(|py| {
         let functools = py.import("functools")?;
         let time = py.import("time")?;
 

--- a/pytests/common/mod.rs
+++ b/pytests/common/mod.rs
@@ -25,7 +25,7 @@ pub(super) async fn test_into_future(event_loop: Py<PyAny>) -> PyResult<()> {
 
         pyo3_async_runtimes::into_future_with_locals(
             &TaskLocals::new(event_loop.into_bound(py)),
-            test_mod.call_method1("py_sleep", (1.into_pyobject(py).unwrap(),))?,
+            test_mod.call_method1("py_sleep", (1,))?,
         )
     })?;
 

--- a/pytests/test_async_std_run_forever.rs
+++ b/pytests/test_async_std_run_forever.rs
@@ -9,20 +9,20 @@ fn dump_err(py: Python, e: PyErr) {
 }
 
 fn main() {
-    pyo3::prepare_freethreaded_python();
+    Python::initialize();
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let asyncio = py.import("asyncio")?;
 
         let event_loop = asyncio.call_method0("new_event_loop")?;
         asyncio.call_method1("set_event_loop", (&event_loop,))?;
 
-        let event_loop_hdl = PyObject::from(event_loop.clone());
+        let event_loop_hdl: Py<PyAny> = event_loop.clone().into();
 
         async_std::task::spawn(async move {
             async_std::task::sleep(Duration::from_secs(1)).await;
 
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 event_loop_hdl
                     .bind(py)
                     .call_method1(
@@ -43,6 +43,6 @@ fn main() {
         println!("test test_async_std_run_forever ... ok");
         Ok(())
     })
-    .map_err(|e| Python::with_gil(|py| dump_err(py, e)))
+    .map_err(|e| Python::attach(|py| dump_err(py, e)))
     .unwrap()
 }

--- a/pytests/test_race_condition_regression.rs
+++ b/pytests/test_race_condition_regression.rs
@@ -48,9 +48,9 @@ def main(rust_sleeper):
 "#;
 
 fn main() -> pyo3::PyResult<()> {
-    pyo3::prepare_freethreaded_python();
+    Python::initialize();
 
-    Python::with_gil(|py| -> PyResult<()> {
+    Python::attach(|py| -> PyResult<()> {
         let sleeper_mod = PyModule::new(py, "rust_sleeper")?;
 
         sleeper_mod.add_wrapped(wrap_pyfunction!(sleep))?;

--- a/pytests/test_tokio_current_thread_asyncio.rs
+++ b/pytests/test_tokio_current_thread_asyncio.rs
@@ -4,9 +4,9 @@ mod tokio_asyncio;
 use pyo3::prelude::*;
 
 fn main() -> pyo3::PyResult<()> {
-    pyo3::prepare_freethreaded_python();
+    Python::initialize();
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let mut builder = tokio::runtime::Builder::new_current_thread();
         builder.enable_all();
 

--- a/pytests/test_tokio_current_thread_run_forever.rs
+++ b/pytests/test_tokio_current_thread_run_forever.rs
@@ -1,7 +1,9 @@
+use pyo3::Python;
+
 mod tokio_run_forever;
 
 fn main() {
-    pyo3::prepare_freethreaded_python();
+    Python::initialize();
 
     let mut builder = tokio::runtime::Builder::new_current_thread();
     builder.enable_all();

--- a/pytests/test_tokio_current_thread_uvloop.rs
+++ b/pytests/test_tokio_current_thread_uvloop.rs
@@ -2,7 +2,7 @@
 fn main() -> pyo3::PyResult<()> {
     use pyo3::{prelude::*, types::PyType};
 
-    pyo3::prepare_freethreaded_python();
+    Python::initialize();
 
     let mut builder = tokio::runtime::Builder::new_current_thread();
     builder.enable_all();
@@ -12,7 +12,7 @@ fn main() -> pyo3::PyResult<()> {
         pyo3_async_runtimes::tokio::get_runtime().block_on(futures::future::pending::<()>());
     });
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         // uvloop not supported on the free-threaded build yet
         // https://github.com/MagicStack/uvloop/issues/642
         let sysconfig = py.import("sysconfig")?;
@@ -25,11 +25,11 @@ fn main() -> pyo3::PyResult<()> {
         uvloop.call_method0("install")?;
 
         // store a reference for the assertion
-        let uvloop = PyObject::from(uvloop);
+        let uvloop: Py<PyAny> = uvloop.into();
 
         pyo3_async_runtimes::tokio::run(py, async move {
             // verify that we are on a uvloop.Loop
-            Python::with_gil(|py| -> PyResult<()> {
+            Python::attach(|py| -> PyResult<()> {
                 assert!(
                     pyo3_async_runtimes::tokio::get_current_loop(py)?.is_instance(
                         uvloop

--- a/pytests/test_tokio_multi_thread_asyncio.rs
+++ b/pytests/test_tokio_multi_thread_asyncio.rs
@@ -4,7 +4,7 @@ mod tokio_asyncio;
 use pyo3::prelude::*;
 
 fn main() -> pyo3::PyResult<()> {
-    pyo3::prepare_freethreaded_python();
+    Python::initialize();
 
-    Python::with_gil(|py| pyo3_async_runtimes::tokio::run(py, pyo3_async_runtimes::testing::main()))
+    Python::attach(|py| pyo3_async_runtimes::tokio::run(py, pyo3_async_runtimes::testing::main()))
 }

--- a/pytests/test_tokio_multi_thread_run_forever.rs
+++ b/pytests/test_tokio_multi_thread_run_forever.rs
@@ -1,7 +1,10 @@
+use pyo3::Python;
+
 mod tokio_run_forever;
 
 fn main() {
-    pyo3::prepare_freethreaded_python();
+    Python::initialize();
+
     tokio_run_forever::test_main();
     println!("test test_tokio_multi_thread_run_forever ... ok");
 }

--- a/pytests/test_tokio_multi_thread_uvloop.rs
+++ b/pytests/test_tokio_multi_thread_uvloop.rs
@@ -2,9 +2,9 @@
 fn main() -> pyo3::PyResult<()> {
     use pyo3::{prelude::*, types::PyType};
 
-    pyo3::prepare_freethreaded_python();
+    Python::initialize();
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         // uvloop not supported on the free-threaded build yet
         // https://github.com/MagicStack/uvloop/issues/642
         let sysconfig = py.import("sysconfig")?;
@@ -17,11 +17,11 @@ fn main() -> pyo3::PyResult<()> {
         uvloop.call_method0("install")?;
 
         // store a reference for the assertion
-        let uvloop = PyObject::from(uvloop);
+        let uvloop: Py<PyAny> = uvloop.into();
 
         pyo3_async_runtimes::tokio::run(py, async move {
             // verify that we are on a uvloop.Loop
-            Python::with_gil(|py| -> PyResult<()> {
+            Python::attach(|py| -> PyResult<()> {
                 assert!(
                     pyo3_async_runtimes::tokio::get_current_loop(py)?.is_instance(
                         uvloop

--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -513,7 +513,7 @@ where
 ///     Python::attach(|py| {
 ///         pyo3_async_runtimes::async_std::into_future(
 ///             test_mod
-///                 .call_method1(py, "py_sleep", (seconds.into_pyobject(py).unwrap(),))?
+///                 .call_method1(py, "py_sleep", (seconds,))?
 ///                 .into_bound(py),
 ///         )
 ///     })?

--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -94,7 +94,7 @@ impl ContextExt for AsyncStdRuntime {
             .try_with(|c| {
                 c.borrow()
                     .as_ref()
-                    .map(|locals| Python::with_gil(|py| locals.clone_ref(py)))
+                    .map(|locals| Python::attach(|py| locals.clone_ref(py)))
             })
             .unwrap_or_default()
     }
@@ -174,9 +174,9 @@ pub fn get_current_locals(py: Python) -> PyResult<TaskLocals> {
 /// #
 /// # use pyo3::prelude::*;
 /// #
-/// # pyo3::prepare_freethreaded_python();
+/// # Python::initialize();
 /// #
-/// # Python::with_gil(|py| -> PyResult<()> {
+/// # Python::attach(|py| -> PyResult<()> {
 /// # let event_loop = py.import("asyncio")?.call_method0("new_event_loop")?;
 /// pyo3_async_runtimes::async_std::run_until_complete(event_loop, async move {
 ///     async_std::task::sleep(Duration::from_secs(1)).await;
@@ -208,9 +208,9 @@ where
 /// #
 /// fn main() {
 ///     // call this or use pyo3 0.14 "auto-initialize" feature
-///     pyo3::prepare_freethreaded_python();
+///     Python::initialize();
 ///
-///     Python::with_gil(|py| {
+///     Python::attach(|py| {
 ///         pyo3_async_runtimes::async_std::run(py, async move {
 ///             async_std::task::sleep(Duration::from_secs(1)).await;
 ///             Ok(())
@@ -268,7 +268,7 @@ where
 ///         pyo3_async_runtimes::async_std::get_current_locals(py)?,
 ///         async move {
 ///             async_std::task::sleep(Duration::from_secs(secs)).await;
-///             Python::with_gil(|py| Ok(py.None()))
+///             Python::attach(|py| Ok(py.None()))
 ///         }
 ///     )
 /// }
@@ -370,7 +370,7 @@ where
 ///         pyo3_async_runtimes::async_std::get_current_locals(py)?,
 ///         async move {
 ///             async_std::task::sleep(Duration::from_secs(*secs)).await;
-///             Python::with_gil(|py| Ok(py.None()))
+///             Python::attach(|py| Ok(py.None()))
 ///         }
 ///     )?.into())
 /// }
@@ -378,7 +378,7 @@ where
 /// # #[cfg(all(feature = "async-std-runtime", feature = "attributes"))]
 /// #[pyo3_async_runtimes::async_std::main]
 /// async fn main() -> PyResult<()> {
-///     Python::with_gil(|py| {
+///     Python::attach(|py| {
 ///         let py_future = sleep_for(py, 1)?;
 ///         pyo3_async_runtimes::async_std::into_future(py_future)
 ///     })?
@@ -448,7 +448,7 @@ where
 /// # #[cfg(all(feature = "async-std-runtime", feature = "attributes"))]
 /// #[pyo3_async_runtimes::async_std::main]
 /// async fn main() -> PyResult<()> {
-///     Python::with_gil(|py| {
+///     Python::attach(|py| {
 ///         let py_future = sleep_for(py, 1)?;
 ///         pyo3_async_runtimes::async_std::into_future(py_future)
 ///     })?
@@ -476,8 +476,8 @@ where
 ///
 /// This function converts the `awaitable` into a Python Task using `run_coroutine_threadsafe`. A
 /// completion handler sends the result of this Task through a
-/// `futures::channel::oneshot::Sender<PyResult<PyObject>>` and the future returned by this function
-/// simply awaits the result through the `futures::channel::oneshot::Receiver<PyResult<PyObject>>`.
+/// `futures::channel::oneshot::Sender<PyResult<Py<PyAny>>>` and the future returned by this function
+/// simply awaits the result through the `futures::channel::oneshot::Receiver<PyResult<Py<PyAny>>>`.
 ///
 /// # Arguments
 /// * `awaitable` - The Python `awaitable` to be converted
@@ -498,7 +498,7 @@ where
 /// "#;
 ///
 /// async fn py_sleep(seconds: f32) -> PyResult<()> {
-///     let test_mod = Python::with_gil(|py| -> PyResult<PyObject> {
+///     let test_mod = Python::attach(|py| -> PyResult<Py<PyAny>> {
 ///         Ok(
 ///             PyModule::from_code(
 ///                 py,
@@ -510,7 +510,7 @@ where
 ///         )
 ///     })?;
 ///
-///     Python::with_gil(|py| {
+///     Python::attach(|py| {
 ///         pyo3_async_runtimes::async_std::into_future(
 ///             test_mod
 ///                 .call_method1(py, "py_sleep", (seconds.into_pyobject(py).unwrap(),))?
@@ -523,7 +523,7 @@ where
 /// ```
 pub fn into_future(
     awaitable: Bound<PyAny>,
-) -> PyResult<impl Future<Output = PyResult<PyObject>> + Send> {
+) -> PyResult<impl Future<Output = PyResult<Py<PyAny>>> + Send> {
     generic::into_future::<AsyncStdRuntime>(awaitable)
 }
 
@@ -554,7 +554,7 @@ pub fn into_future(
 /// # #[cfg(all(feature = "unstable-streams", feature = "attributes"))]
 /// # #[pyo3_async_runtimes::async_std::main]
 /// # async fn main() -> PyResult<()> {
-/// let stream = Python::with_gil(|py| {
+/// let stream = Python::attach(|py| {
 ///     let test_mod = PyModule::from_code(
 ///         py,
 ///         &CString::new(TEST_MOD).unwrap(),
@@ -566,7 +566,7 @@ pub fn into_future(
 /// })?;
 ///
 /// let vals = stream
-///     .map(|item| Python::with_gil(|py| -> PyResult<i32> { Ok(item?.bind(py).extract()?) }))
+///     .map(|item| Python::attach(|py| -> PyResult<i32> { Ok(item?.bind(py).extract()?) }))
 ///     .try_collect::<Vec<i32>>()
 ///     .await?;
 ///
@@ -580,7 +580,7 @@ pub fn into_future(
 #[cfg(feature = "unstable-streams")]
 pub fn into_stream_v1(
     gen: Bound<'_, PyAny>,
-) -> PyResult<impl futures::Stream<Item = PyResult<PyObject>> + 'static> {
+) -> PyResult<impl futures::Stream<Item = PyResult<Py<PyAny>>> + 'static> {
     generic::into_stream_v1::<AsyncStdRuntime>(gen)
 }
 
@@ -612,7 +612,7 @@ pub fn into_stream_v1(
 /// # #[cfg(all(feature = "unstable-streams", feature = "attributes"))]
 /// # #[pyo3_async_runtimes::async_std::main]
 /// # async fn main() -> PyResult<()> {
-/// let stream = Python::with_gil(|py| {
+/// let stream = Python::attach(|py| {
 ///     let test_mod = PyModule::from_code(
 ///         py,
 ///         &CString::new(TEST_MOD).unwrap(),
@@ -627,7 +627,7 @@ pub fn into_stream_v1(
 /// })?;
 ///
 /// let vals = stream
-///     .map(|item| Python::with_gil(|py| -> PyResult<i32> { Ok(item?.bind(py).extract()?) }))
+///     .map(|item| Python::attach(|py| -> PyResult<i32> { Ok(item?.bind(py).extract()?) }))
 ///     .try_collect::<Vec<i32>>()
 ///     .await?;
 ///
@@ -642,7 +642,7 @@ pub fn into_stream_v1(
 pub fn into_stream_with_locals_v1(
     locals: TaskLocals,
     gen: Bound<'_, PyAny>,
-) -> PyResult<impl futures::Stream<Item = PyResult<PyObject>> + 'static> {
+) -> PyResult<impl futures::Stream<Item = PyResult<Py<PyAny>>> + 'static> {
     generic::into_stream_with_locals_v1::<AsyncStdRuntime>(locals, gen)
 }
 
@@ -674,7 +674,7 @@ pub fn into_stream_with_locals_v1(
 /// # #[cfg(all(feature = "unstable-streams", feature = "attributes"))]
 /// # #[pyo3_async_runtimes::async_std::main]
 /// # async fn main() -> PyResult<()> {
-/// let stream = Python::with_gil(|py| {
+/// let stream = Python::attach(|py| {
 ///     let test_mod = PyModule::from_code(
 ///         py,
 ///         &CString::new(TEST_MOD).unwrap(),
@@ -689,7 +689,7 @@ pub fn into_stream_with_locals_v1(
 /// })?;
 ///
 /// let vals = stream
-///     .map(|item| Python::with_gil(|py| -> PyResult<i32> { Ok(item.bind(py).extract()?) }))
+///     .map(|item| Python::attach(|py| -> PyResult<i32> { Ok(item.bind(py).extract()?) }))
 ///     .try_collect::<Vec<i32>>()
 ///     .await?;
 ///
@@ -704,7 +704,7 @@ pub fn into_stream_with_locals_v1(
 pub fn into_stream_with_locals_v2(
     locals: TaskLocals,
     gen: Bound<'_, PyAny>,
-) -> PyResult<impl futures::Stream<Item = PyObject> + 'static> {
+) -> PyResult<impl futures::Stream<Item = Py<PyAny>> + 'static> {
     generic::into_stream_with_locals_v2::<AsyncStdRuntime>(locals, gen)
 }
 
@@ -735,7 +735,7 @@ pub fn into_stream_with_locals_v2(
 /// # #[cfg(all(feature = "unstable-streams", feature = "attributes"))]
 /// # #[pyo3_async_runtimes::async_std::main]
 /// # async fn main() -> PyResult<()> {
-/// let stream = Python::with_gil(|py| {
+/// let stream = Python::attach(|py| {
 ///     let test_mod = PyModule::from_code(
 ///         py,
 ///         &CString::new(TEST_MOD).unwrap(),
@@ -747,7 +747,7 @@ pub fn into_stream_with_locals_v2(
 /// })?;
 ///
 /// let vals = stream
-///     .map(|item| Python::with_gil(|py| -> PyResult<i32> { Ok(item.bind(py).extract()?) }))
+///     .map(|item| Python::attach(|py| -> PyResult<i32> { Ok(item.bind(py).extract()?) }))
 ///     .try_collect::<Vec<i32>>()
 ///     .await?;
 ///
@@ -761,6 +761,6 @@ pub fn into_stream_with_locals_v2(
 #[cfg(feature = "unstable-streams")]
 pub fn into_stream_v2(
     gen: Bound<'_, PyAny>,
-) -> PyResult<impl futures::Stream<Item = PyObject> + 'static> {
+) -> PyResult<impl futures::Stream<Item = Py<PyAny>> + 'static> {
     generic::into_stream_v2::<AsyncStdRuntime>(gen)
 }

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -27,10 +27,9 @@ use crate::{
 use futures::channel::oneshot;
 #[cfg(feature = "unstable-streams")]
 use futures::{channel::mpsc, SinkExt};
-#[cfg(feature = "unstable-streams")]
-use once_cell::sync::OnceCell;
 use pin_project_lite::pin_project;
 use pyo3::prelude::*;
+use pyo3::sync::PyOnceLock;
 use pyo3::IntoPyObjectExt;
 #[cfg(feature = "unstable-streams")]
 use std::marker::PhantomData;
@@ -1660,10 +1659,10 @@ where
 {
     use std::ffi::CString;
 
-    static GLUE_MOD: OnceCell<Py<PyAny>> = OnceCell::new();
+    static GLUE_MOD: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
     let py = gen.py();
     let glue = GLUE_MOD
-        .get_or_try_init(|| -> PyResult<Py<PyAny>> {
+        .get_or_try_init(py, || -> PyResult<Py<PyAny>> {
             Ok(PyModule::from_code(
                 py,
                 &CString::new(STREAM_GLUE).unwrap(),

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -29,7 +29,6 @@ use futures::channel::oneshot;
 use futures::{channel::mpsc, SinkExt};
 use pin_project_lite::pin_project;
 use pyo3::prelude::*;
-use pyo3::sync::PyOnceLock;
 use pyo3::IntoPyObjectExt;
 #[cfg(feature = "unstable-streams")]
 use std::marker::PhantomData;
@@ -1658,6 +1657,8 @@ where
     R: Runtime + ContextExt,
 {
     use std::ffi::CString;
+
+    use pyo3::sync::PyOnceLock;
 
     static GLUE_MOD: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
     let py = gen.py();

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -31,7 +31,7 @@ use futures::{channel::mpsc, SinkExt};
 use once_cell::sync::OnceCell;
 use pin_project_lite::pin_project;
 use pyo3::prelude::*;
-use pyo3::{BoundObject, IntoPyObjectExt};
+use pyo3::IntoPyObjectExt;
 #[cfg(feature = "unstable-streams")]
 use std::marker::PhantomData;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -631,7 +631,7 @@ fn call_soon_threadsafe<'py>(
 ///         pyo3_async_runtimes::into_future_with_locals(
 ///             &pyo3_async_runtimes::tokio::get_current_locals(py)?,
 ///             test_mod
-///                 .call_method1(py, "py_sleep", (seconds.into_pyobject(py).unwrap(),))?
+///                 .call_method1(py, "py_sleep", (seconds,))?
 ///                 .into_bound(py),
 ///         )
 ///     })?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@
 //!
 //!     // Convert the async move { } block to a Python awaitable
 //!     pyo3_async_runtimes::tokio::future_into_py_with_locals(py, locals.clone_ref(py), async move {
-//!         let py_sleep = Python::with_gil(|py| {
+//!         let py_sleep = Python::attach(|py| {
 //!             // Sometimes we need to call other async Python functions within
 //!             // this future. In order for this to work, we need to track the
 //!             // event loop from earlier.
@@ -165,7 +165,7 @@
 //!         locals.clone_ref(py),
 //!         // Store the current locals in task-local data
 //!         pyo3_async_runtimes::tokio::scope(locals.clone_ref(py), async move {
-//!             let py_sleep = Python::with_gil(|py| {
+//!             let py_sleep = Python::attach(|py| {
 //!                 pyo3_async_runtimes::into_future_with_locals(
 //!                     // Now we can get the current locals through task-local data
 //!                     &pyo3_async_runtimes::tokio::get_current_locals(py)?,
@@ -175,7 +175,7 @@
 //!
 //!             py_sleep.await?;
 //!
-//!             Ok(Python::with_gil(|py| py.None()))
+//!             Ok(Python::attach(|py| py.None()))
 //!         })
 //!     )
 //! }
@@ -192,7 +192,7 @@
 //!         locals.clone_ref(py),
 //!         // Store the current locals in task-local data
 //!         pyo3_async_runtimes::tokio::scope(locals.clone_ref(py), async move {
-//!             let py_sleep = Python::with_gil(|py| {
+//!             let py_sleep = Python::attach(|py| {
 //!                 pyo3_async_runtimes::into_future_with_locals(
 //!                     &pyo3_async_runtimes::tokio::get_current_locals(py)?,
 //!                     // We can also call sleep within a Rust task since the
@@ -203,7 +203,7 @@
 //!
 //!             py_sleep.await?;
 //!
-//!             Ok(Python::with_gil(|py| py.None()))
+//!             Ok(Python::attach(|py| py.None()))
 //!         })
 //!     )
 //! }
@@ -242,7 +242,7 @@
 //! #[pyfunction]
 //! fn sleep(py: Python) -> PyResult<Bound<PyAny>> {
 //!     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-//!         let py_sleep = Python::with_gil(|py| {
+//!         let py_sleep = Python::attach(|py| {
 //!             pyo3_async_runtimes::tokio::into_future(
 //!                 py.import("asyncio")?.call_method1("sleep", (1,))?
 //!             )
@@ -250,7 +250,7 @@
 //!
 //!         py_sleep.await?;
 //!
-//!         Ok(Python::with_gil(|py| py.None()))
+//!         Ok(Python::attach(|py| py.None()))
 //!     })
 //! }
 //!
@@ -258,13 +258,13 @@
 //! #[pyfunction]
 //! fn wrap_sleep(py: Python) -> PyResult<Bound<PyAny>> {
 //!     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-//!         let py_sleep = Python::with_gil(|py| {
+//!         let py_sleep = Python::attach(|py| {
 //!             pyo3_async_runtimes::tokio::into_future(sleep(py)?)
 //!         })?;
 //!
 //!         py_sleep.await?;
 //!
-//!         Ok(Python::with_gil(|py| py.None()))
+//!         Ok(Python::attach(|py| py.None()))
 //!     })
 //! }
 //!
@@ -400,21 +400,21 @@ use futures::channel::oneshot;
 use once_cell::sync::OnceCell;
 use pyo3::{call::PyCallArgs, prelude::*, types::PyDict};
 
-static ASYNCIO: OnceCell<PyObject> = OnceCell::new();
-static CONTEXTVARS: OnceCell<PyObject> = OnceCell::new();
-static ENSURE_FUTURE: OnceCell<PyObject> = OnceCell::new();
-static GET_RUNNING_LOOP: OnceCell<PyObject> = OnceCell::new();
+static ASYNCIO: OnceCell<Py<PyAny>> = OnceCell::new();
+static CONTEXTVARS: OnceCell<Py<PyAny>> = OnceCell::new();
+static ENSURE_FUTURE: OnceCell<Py<PyAny>> = OnceCell::new();
+static GET_RUNNING_LOOP: OnceCell<Py<PyAny>> = OnceCell::new();
 
 fn ensure_future<'p>(py: Python<'p>, awaitable: &Bound<'p, PyAny>) -> PyResult<Bound<'p, PyAny>> {
     ENSURE_FUTURE
-        .get_or_try_init(|| -> PyResult<PyObject> {
+        .get_or_try_init(|| -> PyResult<Py<PyAny>> {
             Ok(asyncio(py)?.getattr("ensure_future")?.into())
         })?
         .bind(py)
         .call1((awaitable,))
 }
 
-fn create_future(event_loop: Bound<PyAny>) -> PyResult<Bound<'_, PyAny>> {
+fn create_future(event_loop: Bound<'_, PyAny>) -> PyResult<Bound<'_, PyAny>> {
     event_loop.call_method0("create_future")
 }
 
@@ -437,7 +437,7 @@ fn close(event_loop: Bound<PyAny>) -> PyResult<()> {
     Ok(())
 }
 
-fn asyncio(py: Python) -> PyResult<&Bound<PyAny>> {
+fn asyncio(py: Python<'_>) -> PyResult<&Bound<'_, PyAny>> {
     ASYNCIO
         .get_or_try_init(|| Ok(py.import("asyncio")?.into()))
         .map(|asyncio| asyncio.bind(py))
@@ -450,7 +450,7 @@ pub fn get_running_loop(py: Python) -> PyResult<Bound<PyAny>> {
     // Ideally should call get_running_loop, but calls get_event_loop for compatibility when
     // get_running_loop is not available.
     GET_RUNNING_LOOP
-        .get_or_try_init(|| -> PyResult<PyObject> {
+        .get_or_try_init(|| -> PyResult<Py<PyAny>> {
             let asyncio = asyncio(py)?;
 
             Ok(asyncio.getattr("get_running_loop")?.into())
@@ -459,7 +459,7 @@ pub fn get_running_loop(py: Python) -> PyResult<Bound<PyAny>> {
         .call0()
 }
 
-fn contextvars(py: Python) -> PyResult<&Bound<PyAny>> {
+fn contextvars(py: Python<'_>) -> PyResult<&Bound<'_, PyAny>> {
     Ok(CONTEXTVARS
         .get_or_try_init(|| py.import("contextvars").map(|m| m.into()))?
         .bind(py))
@@ -473,9 +473,9 @@ fn copy_context(py: Python) -> PyResult<Bound<PyAny>> {
 #[derive(Debug)]
 pub struct TaskLocals {
     /// Track the event loop of the Python task
-    event_loop: PyObject,
+    event_loop: Py<PyAny>,
     /// Track the contextvars of the Python task
-    context: PyObject,
+    context: Py<PyAny>,
 }
 
 impl TaskLocals {
@@ -527,7 +527,7 @@ impl TaskLocals {
 
 #[pyclass]
 struct PyTaskCompleter {
-    tx: Option<oneshot::Sender<PyResult<PyObject>>>,
+    tx: Option<oneshot::Sender<PyResult<Py<PyAny>>>>,
 }
 
 #[pymethods]
@@ -556,14 +556,14 @@ impl PyTaskCompleter {
 
 #[pyclass]
 struct PyEnsureFuture {
-    awaitable: PyObject,
-    tx: Option<oneshot::Sender<PyResult<PyObject>>>,
+    awaitable: Py<PyAny>,
+    tx: Option<oneshot::Sender<PyResult<Py<PyAny>>>>,
 }
 
 #[pymethods]
 impl PyEnsureFuture {
     pub fn __call__(&mut self) -> PyResult<()> {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let task = ensure_future(py, self.awaitable.bind(py))?;
             let on_complete = PyTaskCompleter { tx: self.tx.take() };
             task.call_method1("add_done_callback", (on_complete,))?;
@@ -591,8 +591,8 @@ fn call_soon_threadsafe<'py>(
 ///
 /// This function converts the `awaitable` into a Python Task using `run_coroutine_threadsafe`. A
 /// completion handler sends the result of this Task through a
-/// `futures::channel::oneshot::Sender<PyResult<PyObject>>` and the future returned by this function
-/// simply awaits the result through the `futures::channel::oneshot::Receiver<PyResult<PyObject>>`.
+/// `futures::channel::oneshot::Sender<PyResult<Py<PyAny>>>` and the future returned by this function
+/// simply awaits the result through the `futures::channel::oneshot::Receiver<PyResult<Py<PyAny>>>`.
 ///
 /// # Arguments
 /// * `locals` - The Python event loop and context to be used for the provided awaitable
@@ -615,7 +615,7 @@ fn call_soon_threadsafe<'py>(
 ///
 /// # #[cfg(feature = "tokio-runtime")]
 /// async fn py_sleep(seconds: f32) -> PyResult<()> {
-///     let test_mod = Python::with_gil(|py| -> PyResult<PyObject> {
+///     let test_mod = Python::attach(|py| -> PyResult<Py<PyAny>> {
 ///         Ok(
 ///             PyModule::from_code(
 ///                 py,
@@ -627,7 +627,7 @@ fn call_soon_threadsafe<'py>(
 ///         )
 ///     })?;
 ///
-///     Python::with_gil(|py| {
+///     Python::attach(|py| {
 ///         pyo3_async_runtimes::into_future_with_locals(
 ///             &pyo3_async_runtimes::tokio::get_current_locals(py)?,
 ///             test_mod
@@ -642,7 +642,7 @@ fn call_soon_threadsafe<'py>(
 pub fn into_future_with_locals(
     locals: &TaskLocals,
     awaitable: Bound<PyAny>,
-) -> PyResult<impl Future<Output = PyResult<PyObject>> + Send> {
+) -> PyResult<impl Future<Output = PyResult<Py<PyAny>>> + Send> {
     let py = awaitable.py();
     let (tx, rx) = oneshot::channel();
 
@@ -658,7 +658,7 @@ pub fn into_future_with_locals(
     Ok(async move {
         match rx.await {
             Ok(item) => item,
-            Err(_) => Python::with_gil(|py| {
+            Err(_) => Python::attach(|py| {
                 Err(PyErr::from_value(
                     asyncio(py)?.call_method0("CancelledError")?,
                 ))

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -586,7 +586,7 @@ where
 ///     Python::attach(|py| {
 ///         pyo3_async_runtimes::tokio::into_future(
 ///             test_mod
-///                 .call_method1(py, "py_sleep", (seconds.into_pyobject(py).unwrap(),))?
+///                 .call_method1(py, "py_sleep", (seconds,))?
 ///                 .into_bound(py),
 ///         )
 ///     })?


### PR DESCRIPTION
It looks like a release of pyo3 0.26 is [imminent](https://github.com/PyO3/pyo3/releases/tag/v0.26.0).

- Replace `Python::with_gil` with `Python::attach`.
- Replace `pyo3::prepare_freethreaded_python();` with `Python::initialize();`
- Replace `PyObject` with `Py<PyAny>`
- Bump MSRV to 1.74

This uses the git tag for pyo3 0.26 at the moment and will switch to the official crates.io version when 0.26 is published.

cc @davidhewitt 