### PR TITLE
ci: test 3.14, configure trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,18 @@ jobs:
       fail-fast: false # If one platform fails, allow the rest to keep testing.
       matrix:
         rust: [stable]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.13t", "pypy-3.9", "pypy-3.10"]
+        python-version:
+          [
+            "3.9",
+            "3.10",
+            "3.11",
+            "3.12",
+            "3.13",
+            "3.13t",
+            "3.14",
+            "3.14t",
+            "pypy-3.11",
+          ]
         platform:
           [
             {
@@ -66,10 +77,6 @@ jobs:
               rust-target: "x86_64-pc-windows-msvc",
             },
           ]
-        exclude:
-          # PyPy doesn't release 32-bit Windows builds any more
-          - python-version: pypy-3.9
-            platform: { os: "windows-latest", python-architecture: "x86" }
         include:
           # Test minimal supported Rust version
           - rust: 1.63.0
@@ -97,7 +104,12 @@ jobs:
           # Test 32-bit windows just on latest Python
           - rust: stable
             python-version: "3.13"
-            platform: { os: "windows-latest", python-architecture: "x86", rust-target: "i686-pc-windows-msvc" }
+            platform:
+              {
+                os: "windows-latest",
+                python-architecture: "x86",
+                rust-target: "i686-pc-windows-msvc",
+              }
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,18 +4,31 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: The version to build
 
 jobs:
   release:
+    permissions:
+      id-token: write
+
     runs-on: ubuntu-latest
     environment: release
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v5
+        with:
+          # The tag to build or the tag received by the tag event
+          ref: ${{ github.event.inputs.version || github.ref }}
+          persist-credentials: false
 
       - uses: dtolnay/rust-toolchain@stable
+
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
 
       - name: Publish to crates.io
         run: make publish
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
Similar to recent improvements in PyO3:
- test 3.14 in CI
- test PyPy 3.11, stop testing EOL PyPy 3.9 and 3.10
- configure trusted publishing as the source of the authentication for release