### PR TITLE
Move Python::attach calls outside of tokio event loop in future_into_py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ To see unreleased changes, please see the CHANGELOG on the main branch.
 <!-- towncrier release notes start -->
 
 - Avoid attaching to the runtime when cloning TaskLocals by using std::sync::Arc. [#62](https://github.com/PyO3/pyo3-async-runtimes/pull/62)
+- **Breaking**: Finalize the future without holding GIL inside async-std/tokio runtime.
+  Trait `Runtime` now requires `spawn_blocking` function,
+  `future_into_py` functions now require future return type to be `Send`.
+  [#60](https://github.com/PyO3/pyo3-async-runtimes/pull/60)
 
 ## [0.26.0] - 2025-09-02
 

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -94,6 +94,13 @@ impl GenericRuntime for TokioRuntime {
             fut.await;
         })
     }
+
+    fn spawn_blocking<F>(f: F) -> Self::JoinHandle
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        get_runtime().spawn_blocking(f)
+    }
 }
 
 impl ContextExt for TokioRuntime {
@@ -318,7 +325,7 @@ pub fn future_into_py_with_locals<F, T>(
 ) -> PyResult<Bound<PyAny>>
 where
     F: Future<Output = PyResult<T>> + Send + 'static,
-    T: for<'py> IntoPyObject<'py>,
+    T: for<'py> IntoPyObject<'py> + Send + 'static,
 {
     generic::future_into_py_with_locals::<TokioRuntime, F, T>(py, locals, fut)
 }
@@ -364,7 +371,7 @@ where
 pub fn future_into_py<F, T>(py: Python, fut: F) -> PyResult<Bound<PyAny>>
 where
     F: Future<Output = PyResult<T>> + Send + 'static,
-    T: for<'py> IntoPyObject<'py>,
+    T: for<'py> IntoPyObject<'py> + Send + 'static,
 {
     generic::future_into_py::<TokioRuntime, _, T>(py, fut)
 }


### PR DESCRIPTION
Resolved #58 (not sure, completely or not).

Previous PR #62 improves the situation, this improves it further.

~~This PR includes #59.~~