### PR TITLE
No attach when cloning TaskLocals by using std::sync::Arc.

### DIFF
--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -94,7 +94,7 @@ impl ContextExt for AsyncStdRuntime {
             .try_with(|c| {
                 c.borrow()
                     .as_ref()
-                    .map(|locals| Python::attach(|py| locals.clone_ref(py)))
+                    .map(|locals| locals.clone_ref())
             })
             .unwrap_or_default()
     }

--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -94,7 +94,7 @@ impl ContextExt for AsyncStdRuntime {
             .try_with(|c| {
                 c.borrow()
                     .as_ref()
-                    .map(|locals| locals.clone_ref())
+                    .map(|locals| locals.clone())
             })
             .unwrap_or_default()
     }

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -597,11 +597,11 @@ where
     let future_tx2 = future_tx1.clone_ref(py);
 
     R::spawn(async move {
-        let locals2 = locals.clone_ref();
+        let locals2 = locals.clone();
 
         if let Err(e) = R::spawn(async move {
             let result = R::scope(
-                locals2.clone_ref(),
+                locals2.clone(),
                 Cancellable::new_with_cancel_rx(fut, cancel_rx),
             )
             .await;
@@ -1002,11 +1002,11 @@ where
     let future_tx2 = future_tx1.clone_ref(py);
 
     R::spawn_local(async move {
-        let locals2 = locals.clone_ref();
+        let locals2 = locals.clone();
 
         if let Err(e) = R::spawn_local(async move {
             let result = R::scope_local(
-                locals2.clone_ref(),
+                locals2.clone(),
                 Cancellable::new_with_cancel_rx(fut, cancel_rx),
             )
             .await;
@@ -1510,7 +1510,7 @@ impl SenderGlue {
             self.tx
                 .lock()
                 .unwrap()
-                .send(py, self.locals.clone_ref(), item)
+                .send(py, self.locals.clone(), item)
         })
     }
     pub fn close(&mut self) -> PyResult<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@
 //!     let locals = pyo3_async_runtimes::TaskLocals::with_running_loop(py)?.copy_context(py)?;
 //!
 //!     // Convert the async move { } block to a Python awaitable
-//!     pyo3_async_runtimes::tokio::future_into_py_with_locals(py, locals.clone_ref(py), async move {
+//!     pyo3_async_runtimes::tokio::future_into_py_with_locals(py, locals.clone_ref(), async move {
 //!         let py_sleep = Python::attach(|py| {
 //!             // Sometimes we need to call other async Python functions within
 //!             // this future. In order for this to work, we need to track the
@@ -162,9 +162,9 @@
 //!
 //!     pyo3_async_runtimes::tokio::future_into_py_with_locals(
 //!         py,
-//!         locals.clone_ref(py),
+//!         locals.clone_ref(),
 //!         // Store the current locals in task-local data
-//!         pyo3_async_runtimes::tokio::scope(locals.clone_ref(py), async move {
+//!         pyo3_async_runtimes::tokio::scope(locals.clone_ref(), async move {
 //!             let py_sleep = Python::attach(|py| {
 //!                 pyo3_async_runtimes::into_future_with_locals(
 //!                     // Now we can get the current locals through task-local data
@@ -189,9 +189,9 @@
 //!
 //!     pyo3_async_runtimes::tokio::future_into_py_with_locals(
 //!         py,
-//!         locals.clone_ref(py),
+//!         locals.clone_ref(),
 //!         // Store the current locals in task-local data
-//!         pyo3_async_runtimes::tokio::scope(locals.clone_ref(py), async move {
+//!         pyo3_async_runtimes::tokio::scope(locals.clone_ref(), async move {
 //!             let py_sleep = Python::attach(|py| {
 //!                 pyo3_async_runtimes::into_future_with_locals(
 //!                     &pyo3_async_runtimes::tokio::get_current_locals(py)?,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@
 //!     let locals = pyo3_async_runtimes::TaskLocals::with_running_loop(py)?.copy_context(py)?;
 //!
 //!     // Convert the async move { } block to a Python awaitable
-//!     pyo3_async_runtimes::tokio::future_into_py_with_locals(py, locals.clone_ref(), async move {
+//!     pyo3_async_runtimes::tokio::future_into_py_with_locals(py, locals.clone(), async move {
 //!         let py_sleep = Python::attach(|py| {
 //!             // Sometimes we need to call other async Python functions within
 //!             // this future. In order for this to work, we need to track the
@@ -162,9 +162,9 @@
 //!
 //!     pyo3_async_runtimes::tokio::future_into_py_with_locals(
 //!         py,
-//!         locals.clone_ref(),
+//!         locals.clone(),
 //!         // Store the current locals in task-local data
-//!         pyo3_async_runtimes::tokio::scope(locals.clone_ref(), async move {
+//!         pyo3_async_runtimes::tokio::scope(locals.clone(), async move {
 //!             let py_sleep = Python::attach(|py| {
 //!                 pyo3_async_runtimes::into_future_with_locals(
 //!                     // Now we can get the current locals through task-local data
@@ -189,9 +189,9 @@
 //!
 //!     pyo3_async_runtimes::tokio::future_into_py_with_locals(
 //!         py,
-//!         locals.clone_ref(),
+//!         locals.clone(),
 //!         // Store the current locals in task-local data
-//!         pyo3_async_runtimes::tokio::scope(locals.clone_ref(), async move {
+//!         pyo3_async_runtimes::tokio::scope(locals.clone(), async move {
 //!             let py_sleep = Python::attach(|py| {
 //!                 pyo3_async_runtimes::into_future_with_locals(
 //!                     &pyo3_async_runtimes::tokio::get_current_locals(py)?,
@@ -514,10 +514,12 @@ impl TaskLocals {
     pub fn context<'p>(&self, py: Python<'p>) -> Bound<'p, PyAny> {
         self.context.clone_ref(py).into_bound(py)
     }
+}
 
+impl Clone for TaskLocals {
     /// Create a clone of the TaskLocals by incrementing the reference counters of the event loop and
     /// contextvars.
-    pub fn clone_ref(&self) -> Self {
+    fn clone(&self) -> Self {
         Self {
             event_loop: self.event_loop.clone(),
             context: self.context.clone(),

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -111,7 +111,7 @@ impl ContextExt for TokioRuntime {
         TASK_LOCALS
             .try_with(|c| {
                 c.get()
-                    .map(|locals| Python::attach(|py| locals.clone_ref(py)))
+                    .map(|locals| locals.clone_ref())
             })
             .unwrap_or_default()
     }

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -111,7 +111,7 @@ impl ContextExt for TokioRuntime {
         TASK_LOCALS
             .try_with(|c| {
                 c.get()
-                    .map(|locals| locals.clone_ref())
+                    .map(|locals| locals.clone())
             })
             .unwrap_or_default()
     }


### PR DESCRIPTION
As discussed in https://github.com/PyO3/pyo3-async-runtimes/issues/61. Attaching to the runtime isn't free but it happened every time a `TaskLocals` instance was cloned which happens for pretty much any `future_into_py` call.

This was introduced because the old method, directly cloning the python reference without holding the GIL, wasn't sound as described in https://pyo3.rs/main/migration.html#pyclone-is-now-gated-behind-the-py-clone-feature.

While acquiring the GIL is the neater option: all reference counting is handling within the python runtime, it's not strictly necessary. The migration guide mentions using `Arc<Py<T>>` which allows us to reference count the python reference itself on the Rust side. Cloning an `Arc` is very cheap so performance gets a boost.

The only downside is that reasoning about the reference count of a python object becomes more complicated: there's a reference count on both the python object and the Rust side. Fortunately, there is at most one `Arc` per python reference.

Since cloning `TaskLocals` now no longer needs a python runtime, the cloning operation can become an implementation of the `Clone` trait.