### PR TITLE
feat: added smol support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ package.rust-version = "1.83"
 
 [features]
 async-std-runtime = ["async-std"]
+smol-runtime = ["smol", "task-local", "async-executor"]
 attributes = ["pyo3-async-runtimes-macros"]
 testing = ["clap", "inventory"]
 tokio-runtime = ["tokio"]
@@ -32,15 +33,20 @@ unstable-streams = [
     "futures-util/sink",
     "futures-channel/sink",
 ]
-default = []
+default = ["smol-runtime"]
 
 [package.metadata.docs.rs]
-features = ["attributes", "testing", "async-std-runtime", "tokio-runtime"]
+features = ["attributes", "testing", "async-std-runtime", "tokio-runtime", "smol-runtime"]
 
 [[example]]
 name = "async_std"
 path = "examples/async_std.rs"
 required-features = ["attributes", "async-std-runtime"]
+
+[[example]]
+name = "smol"
+path = "examples/smol.rs"
+required-features = ["attributes", "smol-runtime"]
 
 [[example]]
 name = "tokio"
@@ -67,6 +73,18 @@ required-features = ["async-std-runtime", "testing", "attributes"]
 [[test]]
 name = "test_async_std_run_forever"
 path = "pytests/test_async_std_run_forever.rs"
+harness = false
+required-features = ["async-std-runtime", "testing"]
+
+[[test]]
+name = "test_smol_asyncio"
+path = "pytests/test_smol_asyncio.rs"
+harness = false
+required-features = ["smol-runtime", "testing", "attributes"]
+
+[[test]]
+name = "test_smol_run_forever"
+path = "pytests/test_smol_run_forever.rs"
 harness = false
 required-features = ["async-std-runtime", "testing"]
 
@@ -101,6 +119,12 @@ harness = false
 required-features = ["async-std-runtime", "testing"]
 
 [[test]]
+name = "test_smol_uvloop"
+path = "pytests/test_smol_uvloop.rs"
+harness = false
+required-features = ["smol-runtime", "testing"]
+
+[[test]]
 name = "test_tokio_current_thread_uvloop"
 path = "pytests/test_tokio_current_thread_uvloop.rs"
 harness = false
@@ -121,6 +145,7 @@ required-features = ["async-std-runtime", "testing"]
 
 [dependencies]
 async-channel = { version = "2.3", optional = true }
+async-executor = { version = "1.14.0", optional = true }
 clap = { version = "4.5", optional = true }
 futures-channel = "0.3"
 futures-util = "0.3"
@@ -129,6 +154,7 @@ once_cell = "1.14"
 pin-project-lite = "0.2"
 pyo3 = "0.28"
 pyo3-async-runtimes-macros = { path = "pyo3-async-runtimes-macros", version = "=0.28.0", optional = true }
+task-local = { version = "0.1.0", optional = true }
 
 [dev-dependencies]
 pyo3 = { version = "0.28", features = ["macros"] }
@@ -136,6 +162,10 @@ pyo3 = { version = "0.28", features = ["macros"] }
 [dependencies.async-std]
 version = "1.12"
 features = ["unstable"]
+optional = true
+
+[dependencies.smol]
+version = "2.0.2"
 optional = true
 
 [dependencies.tokio]

--- a/examples/smol.rs
+++ b/examples/smol.rs
@@ -1,0 +1,17 @@
+use pyo3::prelude::*;
+
+#[pyo3_async_runtimes::smol::main]
+async fn main() -> PyResult<()> {
+    let fut = Python::attach(|py| {
+        let asyncio = py.import("asyncio")?;
+
+        // convert asyncio.sleep into a Rust Future
+        pyo3_async_runtimes::smol::into_future(asyncio.call_method1("sleep", (1,))?)
+    })?;
+
+    println!("sleeping for 1s");
+    fut.await?;
+    println!("done");
+
+    Ok(())
+}

--- a/pyo3-async-runtimes-macros/src/lib.rs
+++ b/pyo3-async-runtimes-macros/src/lib.rs
@@ -64,6 +64,62 @@ pub fn async_std_main(_attr: TokenStream, item: TokenStream) -> TokenStream {
     result.into()
 }
 
+/// Enables an async main function that uses the async-std runtime.
+///
+/// # Examples
+///
+/// ```ignore
+/// #[pyo3_async_runtimes::smol::main]
+/// async fn main() -> PyResult<()> {
+///     Ok(())
+/// }
+/// ```
+#[cfg(not(test))] // NOTE: exporting main breaks tests, we should file an issue.
+#[proc_macro_attribute]
+pub fn smol_main(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(item as syn::ItemFn);
+
+    let ret = &input.sig.output;
+    let inputs = &input.sig.inputs;
+    let name = &input.sig.ident;
+    let body = &input.block;
+    let attrs = &input.attrs;
+    let vis = &input.vis;
+
+    if name != "main" {
+        return TokenStream::from(quote_spanned! { name.span() =>
+            compile_error!("only the main function can be tagged with #[async_std::main]"),
+        });
+    }
+
+    if input.sig.asyncness.is_none() {
+        return TokenStream::from(quote_spanned! { input.span() =>
+            compile_error!("the async keyword is missing from the function declaration"),
+        });
+    }
+
+    let result = quote! {
+        #vis fn main() {
+            #(#attrs)*
+            async fn main(#inputs) #ret {
+                #body
+            }
+
+            pyo3::Python::initialize();
+
+            pyo3::Python::attach(|py| {
+                pyo3_async_runtimes::smol::run(py, main())
+                    .map_err(|e| {
+                        e.print_and_set_sys_last_vars(py);
+                    })
+                    .unwrap();
+            });
+        }
+    };
+
+    result.into()
+}
+
 /// Enables an async main function that uses the tokio runtime.
 ///
 /// # Arguments
@@ -158,6 +214,103 @@ pub fn async_std_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
                     pyo3_async_runtimes::async_std::get_current_loop(py).unwrap().into()
                 });
                 Box::pin(pyo3_async_runtimes::async_std::re_exports::spawn_blocking(move || {
+                    #name(event_loop)
+                }))
+            }
+        };
+
+        quote! {
+            #vis fn #name() -> std::pin::Pin<Box<dyn std::future::Future<Output = pyo3::PyResult<()>> + Send>> {
+                #sig {
+                    #body
+                }
+
+                #task
+            }
+        }
+    } else {
+        quote! {
+            #vis fn #name() -> std::pin::Pin<Box<dyn std::future::Future<Output = pyo3::PyResult<()>> + Send>> {
+                #sig {
+                    #body
+                }
+
+                Box::pin(#name())
+            }
+        }
+    };
+
+    let result = quote! {
+        #fn_impl
+
+        pyo3_async_runtimes::inventory::submit! {
+            pyo3_async_runtimes::testing::Test {
+                name: concat!(std::module_path!(), "::", stringify!(#name)),
+                test_fn: &#name
+            }
+        }
+    };
+
+    result.into()
+}
+
+/// Registers an `async-std` test with the `pyo3-asyncio` test harness.
+///
+/// This attribute is meant to mirror the `#[test]` attribute and allow you to mark a function for
+/// testing within an integration test. Like the `#[smol::test]` attribute, it will accept
+/// `async` test functions, but it will also accept blocking functions as well.
+///
+/// # Examples
+/// ```ignore
+/// use std::{time::Duration, thread};
+///
+/// use pyo3::prelude::*;
+///
+/// // async test function
+/// #[pyo3_async_runtimes::smol::test]
+/// async fn test_async_sleep() -> PyResult<()> {
+///     smol::Timer::after(Duration::from_secs(1)).await;
+///     Ok(())
+/// }
+///
+/// // blocking test function
+/// #[pyo3_async_runtimes::smol::test]
+/// fn test_blocking_sleep() -> PyResult<()> {
+///     thread::sleep(Duration::from_secs(1));
+///     Ok(())
+/// }
+///
+/// // blocking test functions can optionally accept an event_loop parameter
+/// #[pyo3_async_runtimes::smol::test]
+/// fn test_blocking_sleep_with_event_loop(event_loop: Py<PyAny>) -> PyResult<()> {
+///     thread::sleep(Duration::from_secs(1));
+///     Ok(())
+/// }
+/// ```
+#[cfg(not(test))] // NOTE: exporting main breaks tests, we should file an issue.
+#[proc_macro_attribute]
+pub fn smol_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(item as syn::ItemFn);
+
+    let sig = &input.sig;
+    let name = &input.sig.ident;
+    let body = &input.block;
+    let vis = &input.vis;
+
+    let fn_impl = if input.sig.asyncness.is_none() {
+        // Optionally pass an event_loop parameter to blocking tasks
+        let task = if sig.inputs.is_empty() {
+            quote! {
+                Box::pin(pyo3_async_runtimes::smol::re_exports::spawn_blocking(move || {
+                    #name()
+                }))
+            }
+        } else {
+            quote! {
+                let event_loop = pyo3::Python::attach(|py| {
+                    pyo3_async_runtimes::smol::get_current_loop(py).unwrap().into()
+                });
+                Box::pin(pyo3_async_runtimes::smol::re_exports::spawn_blocking(move || {
                     #name(event_loop)
                 }))
             }

--- a/pytests/common copy/mod.rs
+++ b/pytests/common copy/mod.rs
@@ -1,0 +1,65 @@
+use std::ffi::CString;
+use std::{thread, time::Duration};
+
+use pyo3::prelude::*;
+use pyo3_async_runtimes::TaskLocals;
+
+pub(super) const TEST_MOD: &str = r#"
+import asyncio
+
+async def py_sleep(duration):
+    await asyncio.sleep(duration)
+
+async def sleep_for_1s(sleep_for):
+    await sleep_for(1)
+"#;
+
+pub(super) async fn test_into_future(event_loop: Py<PyAny>) -> PyResult<()> {
+    let fut = Python::attach(|py| {
+        let test_mod = PyModule::from_code(
+            py,
+            &CString::new(TEST_MOD).unwrap(),
+            &CString::new("test_rust_coroutine/test_mod.py").unwrap(),
+            &CString::new("test_mod").unwrap(),
+        )?;
+
+        pyo3_async_runtimes::into_future_with_locals(
+            &TaskLocals::new(event_loop.into_bound(py)),
+            test_mod.call_method1("py_sleep", (1,))?,
+        )
+    })?;
+
+    fut.await?;
+
+    Ok(())
+}
+
+pub(super) fn test_blocking_sleep() -> PyResult<()> {
+    thread::sleep(Duration::from_secs(1));
+    Ok(())
+}
+
+pub(super) async fn test_other_awaitables(event_loop: Py<PyAny>) -> PyResult<()> {
+    let fut = Python::attach(|py| {
+        let functools = py.import("functools")?;
+        let time = py.import("time")?;
+
+        // spawn a blocking sleep in the threadpool executor - returns a task, not a coroutine
+        let task = event_loop.bind(py).call_method1(
+            "run_in_executor",
+            (
+                py.None(),
+                functools.call_method1("partial", (time.getattr("sleep")?, 1))?,
+            ),
+        )?;
+
+        pyo3_async_runtimes::into_future_with_locals(
+            &TaskLocals::new(event_loop.into_bound(py)),
+            task,
+        )
+    })?;
+
+    fut.await?;
+
+    Ok(())
+}

--- a/pytests/test_smol_asyncio.rs
+++ b/pytests/test_smol_asyncio.rs
@@ -1,0 +1,419 @@
+mod common;
+
+use std::ffi::CString;
+use std::{
+    rc::Rc,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use pyo3::{
+    prelude::*,
+    types::{IntoPyDict, PyType},
+    wrap_pyfunction, wrap_pymodule,
+};
+use pyo3_async_runtimes::TaskLocals;
+
+#[cfg(feature = "unstable-streams")]
+use futures_util::stream::{StreamExt, TryStreamExt};
+
+#[pyfunction]
+fn sleep<'p>(py: Python<'p>, secs: Bound<'p, PyAny>) -> PyResult<Bound<'p, PyAny>> {
+    let secs = secs.extract()?;
+
+    pyo3_async_runtimes::smol::future_into_py(py, async move {
+        smol::Timer::after(Duration::from_secs(secs)).await;
+        Ok(())
+    })
+}
+
+#[pyo3_async_runtimes::smol::test]
+async fn test_future_into_py() -> PyResult<()> {
+    let fut = Python::attach(|py| {
+        let sleeper_mod = PyModule::new(py, "rust_sleeper")?;
+
+        sleeper_mod.add_wrapped(wrap_pyfunction!(sleep))?;
+
+        let test_mod = PyModule::from_code(
+            py,
+            &CString::new(common::TEST_MOD).unwrap(),
+            &CString::new("test_future_into_py_mod.py").unwrap(),
+            &CString::new("test_future_into_py_mod").unwrap(),
+        )?;
+
+        pyo3_async_runtimes::smol::into_future(
+            test_mod.call_method1("sleep_for_1s", (sleeper_mod.getattr("sleep")?,))?,
+        )
+    })?;
+
+    fut.await?;
+
+    Ok(())
+}
+
+#[pyo3_async_runtimes::smol::test]
+async fn test_async_sleep() -> PyResult<()> {
+    let asyncio = Python::attach(|py| py.import("asyncio").map(Py::<PyAny>::from))?;
+
+    smol::Timer::after(Duration::from_secs(1)).await;
+
+    Python::attach(|py| {
+        pyo3_async_runtimes::smol::into_future(asyncio.bind(py).call_method1("sleep", (1.0,))?)
+    })?
+    .await?;
+
+    Ok(())
+}
+
+#[pyo3_async_runtimes::smol::test]
+fn test_blocking_sleep() -> PyResult<()> {
+    common::test_blocking_sleep()
+}
+
+#[pyo3_async_runtimes::smol::test]
+async fn test_into_future() -> PyResult<()> {
+    common::test_into_future(Python::attach(|py| {
+        pyo3_async_runtimes::smol::get_current_loop(py)
+            .unwrap()
+            .into()
+    }))
+    .await
+}
+
+#[pyo3_async_runtimes::smol::test]
+async fn test_other_awaitables() -> PyResult<()> {
+    common::test_other_awaitables(Python::attach(|py| {
+        pyo3_async_runtimes::smol::get_current_loop(py)
+            .unwrap()
+            .into()
+    }))
+    .await
+}
+
+#[pyo3_async_runtimes::smol::test]
+async fn test_panic() -> PyResult<()> {
+    let fut = Python::attach(|py| -> PyResult<_> {
+        pyo3_async_runtimes::smol::into_future(
+            pyo3_async_runtimes::smol::future_into_py::<_, ()>(py, async {
+                panic!("this panic was intentional!")
+            })?,
+        )
+    })?;
+
+    match fut.await {
+        Ok(_) => panic!("coroutine should panic"),
+        Err(e) => Python::attach(|py| {
+            if e.is_instance_of::<pyo3_async_runtimes::err::RustPanic>(py) {
+                Ok(())
+            } else {
+                panic!("expected RustPanic err")
+            }
+        }),
+    }
+}
+
+#[pyo3_async_runtimes::smol::test]
+async fn test_local_future_into_py() -> PyResult<()> {
+    Python::attach(|py| {
+        let non_send_secs = Rc::new(1);
+
+        #[allow(deprecated)]
+        let py_future = pyo3_async_runtimes::smol::local_future_into_py(py, async move {
+            smol::Timer::after(Duration::from_secs(*non_send_secs)).await;
+            Ok(())
+        })?;
+
+        pyo3_async_runtimes::smol::into_future(py_future)
+    })?
+    .await?;
+
+    Ok(())
+}
+
+#[pyo3_async_runtimes::smol::test]
+async fn test_cancel() -> PyResult<()> {
+    let completed = Arc::new(Mutex::new(false));
+
+    let py_future = Python::attach(|py| -> PyResult<Py<PyAny>> {
+        let completed = Arc::clone(&completed);
+        Ok(
+            pyo3_async_runtimes::smol::future_into_py(py, async move {
+                smol::Timer::after(Duration::from_secs(1)).await;
+                *completed.lock().unwrap() = true;
+
+                Ok(())
+            })?
+            .into(),
+        )
+    })?;
+
+    if let Err(e) = Python::attach(|py| -> PyResult<_> {
+        py_future.bind(py).call_method0("cancel")?;
+        pyo3_async_runtimes::smol::into_future(py_future.into_bound(py))
+    })?
+    .await
+    {
+        Python::attach(|py| -> PyResult<()> {
+            assert!(e.value(py).is_instance(
+                py.import("asyncio")?
+                    .getattr("CancelledError")?
+                    .cast::<PyType>()
+                    .unwrap()
+            )?);
+            Ok(())
+        })?;
+    } else {
+        panic!("expected CancelledError");
+    }
+
+    smol::Timer::after(Duration::from_secs(1)).await;
+    if *completed.lock().unwrap() {
+        panic!("future still completed")
+    }
+
+    Ok(())
+}
+
+#[cfg(feature = "unstable-streams")]
+const ASYNC_STD_TEST_MOD: &str = r#"
+import asyncio
+
+async def gen():
+    for i in range(10):
+        await asyncio.sleep(0.1)
+        yield i
+"#;
+
+#[cfg(feature = "unstable-streams")]
+#[pyo3_async_runtimes::smol::test]
+async fn test_async_gen_v1() -> PyResult<()> {
+    let stream = Python::attach(|py| {
+        let test_mod = PyModule::from_code(
+            py,
+            &CString::new(ASYNC_STD_TEST_MOD).unwrap(),
+            &CString::new("test_rust_coroutine/async_std_test_mod.py").unwrap(),
+            &CString::new("async_std_test_mod").unwrap(),
+        )?;
+
+        pyo3_async_runtimes::smol::into_stream_v1(test_mod.call_method0("gen")?)
+    })?;
+
+    let vals = stream
+        .map(|item| Python::attach(|py| -> PyResult<i32> { item?.bind(py).extract() }))
+        .try_collect::<Vec<i32>>()
+        .await?;
+
+    assert_eq!((0..10).collect::<Vec<i32>>(), vals);
+
+    Ok(())
+}
+
+#[pyo3_async_runtimes::smol::test]
+fn test_local_cancel(event_loop: Py<PyAny>) -> PyResult<()> {
+    let locals = Python::attach(|py| -> PyResult<TaskLocals> {
+        TaskLocals::new(event_loop.into_bound(py)).copy_context(py)
+    })?;
+    smol::block_on(pyo3_async_runtimes::smol::scope_local(locals, async {
+        let completed = Arc::new(Mutex::new(false));
+
+        let py_future = Python::attach(|py| -> PyResult<Py<PyAny>> {
+            let completed = Arc::clone(&completed);
+            Ok(
+                pyo3_async_runtimes::smol::future_into_py(py, async move {
+                    smol::Timer::after(Duration::from_secs(1)).await;
+                    *completed.lock().unwrap() = true;
+
+                    Ok(())
+                })?
+                .into(),
+            )
+        })?;
+
+        if let Err(e) = Python::attach(|py| -> PyResult<_> {
+            py_future.bind(py).call_method0("cancel")?;
+            pyo3_async_runtimes::smol::into_future(py_future.into_bound(py))
+        })?
+        .await
+        {
+            Python::attach(|py| -> PyResult<()> {
+                assert!(e.value(py).is_instance(
+                    py.import("asyncio")?
+                        .getattr("CancelledError")?
+                        .cast::<PyType>()
+                        .unwrap()
+                )?);
+                Ok(())
+            })?;
+        } else {
+            panic!("expected CancelledError");
+        }
+
+        smol::Timer::after(Duration::from_secs(1)).await;
+        if *completed.lock().unwrap() {
+            panic!("future still completed")
+        }
+
+        Ok(())
+    }))
+}
+
+/// This module is implemented in Rust.
+#[pymodule]
+fn test_mod(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
+    #![allow(deprecated)]
+    #[pyfunction(name = "sleep")]
+    fn sleep_(py: Python) -> PyResult<Bound<PyAny>> {
+        pyo3_async_runtimes::smol::future_into_py(py, async move {
+            smol::Timer::after(Duration::from_millis(500)).await;
+            Ok(())
+        })
+    }
+
+    m.add_function(wrap_pyfunction!(sleep_, m)?)?;
+
+    Ok(())
+}
+
+const MULTI_ASYNCIO_CODE: &str = r#"
+async def main():
+    return await test_mod.sleep()
+
+asyncio.new_event_loop().run_until_complete(main())
+"#;
+
+#[pyo3_async_runtimes::smol::test]
+fn test_multiple_asyncio_run() -> PyResult<()> {
+    Python::attach(|py| {
+        pyo3_async_runtimes::smol::run(py, async move {
+            smol::Timer::after(Duration::from_millis(500)).await;
+            Ok(())
+        })?;
+        pyo3_async_runtimes::smol::run(py, async move {
+            smol::Timer::after(Duration::from_millis(500)).await;
+            Ok(())
+        })?;
+
+        let d = [
+            ("asyncio", py.import("asyncio")?.into()),
+            ("test_mod", wrap_pymodule!(test_mod)(py)),
+        ]
+        .into_py_dict(py)?;
+
+        py.run(&CString::new(MULTI_ASYNCIO_CODE).unwrap(), Some(&d), None)?;
+        py.run(&CString::new(MULTI_ASYNCIO_CODE).unwrap(), Some(&d), None)?;
+        Ok(())
+    })
+}
+
+#[pymodule]
+fn cvars_mod(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
+    #![allow(deprecated)]
+    #[pyfunction]
+    pub(crate) fn async_callback(py: Python, callback: Py<PyAny>) -> PyResult<Bound<PyAny>> {
+        pyo3_async_runtimes::smol::future_into_py(py, async move {
+            Python::attach(|py| {
+                pyo3_async_runtimes::smol::into_future(callback.bind(py).call0()?)
+            })?
+            .await?;
+
+            Ok(())
+        })
+    }
+
+    m.add_function(wrap_pyfunction!(async_callback, m)?)?;
+
+    Ok(())
+}
+
+#[cfg(feature = "unstable-streams")]
+#[pyo3_async_runtimes::smol::test]
+async fn test_async_gen_v2() -> PyResult<()> {
+    let stream = Python::attach(|py| {
+        let test_mod = PyModule::from_code(
+            py,
+            &CString::new(ASYNC_STD_TEST_MOD).unwrap(),
+            &CString::new("test_rust_coroutine/async_std_test_mod.py").unwrap(),
+            &CString::new("async_std_test_mod").unwrap(),
+        )?;
+
+        pyo3_async_runtimes::smol::into_stream_v2(test_mod.call_method0("gen")?)
+    })?;
+
+    let vals = stream
+        .map(|item| Python::attach(|py| -> PyResult<i32> { item.bind(py).extract() }))
+        .try_collect::<Vec<i32>>()
+        .await?;
+
+    assert_eq!((0..10).collect::<Vec<i32>>(), vals);
+
+    Ok(())
+}
+
+#[cfg(feature = "unstable-streams")]
+const ASYNC_STD_TEST_MOD_FASTGEN: &str = r#"
+
+async def gen():
+    for i in range(1000):
+        yield i
+"#;
+
+#[cfg(feature = "unstable-streams")]
+#[pyo3_async_runtimes::smol::test]
+async fn test_async_gen_full_buffer() -> PyResult<()> {
+    let stream = Python::attach(|py| {
+        let test_mod = PyModule::from_code(
+            py,
+            &CString::new(ASYNC_STD_TEST_MOD_FASTGEN).unwrap(),
+            &CString::new("test_rust_coroutine/async_std_test_mod.py").unwrap(),
+            &CString::new("async_std_test_mod").unwrap(),
+        )?;
+
+        pyo3_async_runtimes::smol::into_stream_v2(test_mod.call_method0("gen")?)
+    })?;
+
+    let vals = stream
+        .map(|item| Python::attach(|py| -> PyResult<i32> { item.bind(py).extract() }))
+        .try_collect::<Vec<i32>>()
+        .await?;
+
+    assert_eq!((0..1000).collect::<Vec<i32>>(), vals);
+
+    Ok(())
+}
+
+const CONTEXTVARS_CODE: &str = r#"
+cx = contextvars.ContextVar("cx")
+
+async def contextvars_test():
+    assert cx.get() == "foobar"
+
+async def main():
+    cx.set("foobar")
+    await cvars_mod.async_callback(contextvars_test)
+
+asyncio.run(main())
+"#;
+
+#[pyo3_async_runtimes::smol::test]
+fn test_contextvars() -> PyResult<()> {
+    Python::attach(|py| {
+        let d = [
+            ("asyncio", py.import("asyncio")?.into()),
+            ("contextvars", py.import("contextvars")?.into()),
+            ("cvars_mod", wrap_pymodule!(cvars_mod)(py)),
+        ]
+        .into_py_dict(py)?;
+
+        py.run(&CString::new(CONTEXTVARS_CODE).unwrap(), Some(&d), None)?;
+        py.run(&CString::new(CONTEXTVARS_CODE).unwrap(), Some(&d), None)?;
+        Ok(())
+    })
+}
+
+fn main() -> pyo3::PyResult<()> {
+    Python::initialize();
+
+    Python::attach(|py| {
+        pyo3_async_runtimes::smol::run(py, pyo3_async_runtimes::testing::main())
+    })
+}

--- a/pytests/test_smol_run_forever.rs
+++ b/pytests/test_smol_run_forever.rs
@@ -1,0 +1,48 @@
+use std::time::Duration;
+
+use pyo3::prelude::*;
+
+fn dump_err(py: Python, e: PyErr) {
+    // We can't display Python exceptions via std::fmt::Display,
+    // so print the error here manually.
+    e.print_and_set_sys_last_vars(py);
+}
+
+fn main() {
+    Python::initialize();
+
+    Python::attach(|py| {
+        let asyncio = py.import("asyncio")?;
+
+        let event_loop = asyncio.call_method0("new_event_loop")?;
+        asyncio.call_method1("set_event_loop", (&event_loop,))?;
+
+        let event_loop_hdl: Py<PyAny> = event_loop.clone().into();
+
+        smol::spawn(async move {
+            smol::Timer::after(Duration::from_secs(1)).await;
+
+            Python::attach(|py| {
+                event_loop_hdl
+                    .bind(py)
+                    .call_method1(
+                        "call_soon_threadsafe",
+                        (event_loop_hdl
+                            .bind(py)
+                            .getattr("stop")
+                            .map_err(|e| dump_err(py, e))
+                            .unwrap(),),
+                    )
+                    .map_err(|e| dump_err(py, e))
+                    .unwrap();
+            })
+        });
+
+        event_loop.call_method0("run_forever")?;
+
+        println!("test test_async_std_run_forever ... ok");
+        Ok(())
+    })
+    .map_err(|e| Python::attach(|py| dump_err(py, e)))
+    .unwrap()
+}

--- a/pytests/test_smol_uvloop.rs
+++ b/pytests/test_smol_uvloop.rs
@@ -1,0 +1,43 @@
+#[cfg(not(target_os = "windows"))]
+fn main() -> pyo3::PyResult<()> {
+    use pyo3::{prelude::*, types::PyType};
+    Python::initialize();
+
+    Python::attach(|py| {
+        // uvloop not supported on the free-threaded build yet
+        // https://github.com/MagicStack/uvloop/issues/642
+        let sysconfig = py.import("sysconfig")?;
+        let is_freethreaded = sysconfig.call_method1("get_config_var", ("Py_GIL_DISABLED",))?;
+        if is_freethreaded.is_truthy()? {
+            return Ok(());
+        }
+
+        // uvloop not yet supported on 3.14
+        if py.version_info() >= (3, 14) {
+            return Ok(());
+        }
+
+        let uvloop = py.import("uvloop")?;
+        uvloop.call_method0("install")?;
+
+        // store a reference for the assertion
+        let uvloop: Py<PyAny> = uvloop.into();
+
+        pyo3_async_runtimes::smol::run(py, async move {
+            // verify that we are on a uvloop.Loop
+            Python::attach(|py| -> PyResult<()> {
+                assert!(pyo3_async_runtimes::smol::get_current_loop(py)?
+                    .is_instance(uvloop.bind(py).getattr("Loop")?.cast::<PyType>().unwrap())?);
+                Ok(())
+            })?;
+
+            smol::Timer::after(std::time::Duration::from_secs(1)).await;
+
+            println!("test test_smol_uvloop ... ok");
+            Ok(())
+        })
+    })
+}
+
+#[cfg(target_os = "windows")]
+fn main() {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -351,11 +351,14 @@ pub use inventory;
 #[cfg(feature = "testing")]
 pub mod testing;
 
-#[cfg(feature = "async-std")]
+#[cfg(feature = "async-std-runtime")]
 pub mod async_std;
 
 #[cfg(feature = "tokio-runtime")]
 pub mod tokio;
+
+#[cfg(feature = "smol-runtime")]
+pub mod smol;
 
 /// Errors and exceptions related to PyO3 Asyncio
 pub mod err;
@@ -389,6 +392,7 @@ pub mod doc_test {
     #[cfg(all(
         feature = "async-std-runtime",
         feature = "tokio-runtime",
+        feature = "smol-runtime",
         feature = "attributes"
     ))]
     doctest!("../README.md", readme_md);

--- a/src/smol.rs
+++ b/src/smol.rs
@@ -14,10 +14,16 @@
 //! features = ["unstable-streams"]
 //! ```
 
-use async_std::task;
 use futures_util::future::FutureExt;
 use pyo3::prelude::*;
-use std::{any::Any, cell::RefCell, future::Future, panic, panic::AssertUnwindSafe, pin::Pin};
+use std::{
+    any::Any,
+    cell::RefCell,
+    future::Future,
+    panic::{self, AssertUnwindSafe},
+    pin::Pin,
+};
+use task_local::task_local;
 
 use crate::{
     generic::{self, ContextExt, JoinError, LocalContextExt, Runtime, SpawnLocalExt},
@@ -29,22 +35,22 @@ use crate::{
 #[cfg(feature = "attributes")]
 pub mod re_exports {
     /// re-export spawn_blocking for use in `#[test]` macro without external dependency
-    pub use async_std::task::spawn_blocking;
+    pub use smol::unblock as spawn_blocking;
 }
 
 /// <span class="module-item stab portability" style="display: inline; border-radius: 3px; padding: 2px; font-size: 80%; line-height: 1.2;"><code>attributes</code></span> Provides the boilerplate for the `async-std` runtime and runs an async fn as main
 #[cfg(feature = "attributes")]
-pub use pyo3_async_runtimes_macros::async_std_main as main;
+pub use pyo3_async_runtimes_macros::smol_main as main;
 
 /// <span class="module-item stab portability" style="display: inline; border-radius: 3px; padding: 2px; font-size: 80%; line-height: 1.2;"><code>attributes</code></span>
 /// <span class="module-item stab portability" style="display: inline; border-radius: 3px; padding: 2px; font-size: 80%; line-height: 1.2;"><code>testing</code></span>
 /// Registers an `async-std` test with the `pyo3-asyncio` test harness
 #[cfg(all(feature = "attributes", feature = "testing"))]
-pub use pyo3_async_runtimes_macros::async_std_test as test;
+pub use pyo3_async_runtimes_macros::smol_test as test;
 
-struct AsyncStdJoinErr(Box<dyn Any + Send + 'static>);
+struct SmolJoinErr(Box<dyn Any + Send + 'static>);
 
-impl JoinError for AsyncStdJoinErr {
+impl JoinError for SmolJoinErr {
     fn is_panic(&self) -> bool {
         true
     }
@@ -53,25 +59,25 @@ impl JoinError for AsyncStdJoinErr {
     }
 }
 
-async_std::task_local! {
-    static TASK_LOCALS: RefCell<Option<TaskLocals>> = RefCell::new(None);
+task_local! {
+    static TASK_LOCALS: RefCell<Option<TaskLocals>>;
 }
 
-struct AsyncStdRuntime;
+struct SmolRuntime;
 
-impl Runtime for AsyncStdRuntime {
-    type JoinError = AsyncStdJoinErr;
-    type JoinHandle = task::JoinHandle<Result<(), AsyncStdJoinErr>>;
+impl Runtime for SmolRuntime {
+    type JoinError = SmolJoinErr;
+    type JoinHandle = smol::Task<Result<(), SmolJoinErr>>;
 
     fn spawn<F>(fut: F) -> Self::JoinHandle
     where
         F: Future<Output = ()> + Send + 'static,
     {
-        task::spawn(async move {
+        smol::spawn(async move {
             AssertUnwindSafe(fut)
                 .catch_unwind()
                 .await
-                .map_err(AsyncStdJoinErr)
+                .map_err(SmolJoinErr)
         })
     }
 
@@ -79,13 +85,13 @@ impl Runtime for AsyncStdRuntime {
     where
         F: FnOnce() + Send + 'static,
     {
-        task::spawn_blocking(move || {
-            panic::catch_unwind(AssertUnwindSafe(f)).map_err(|e| AsyncStdJoinErr(Box::new(e)))
+        smol::unblock(move || {
+            panic::catch_unwind(AssertUnwindSafe(f)).map_err(|e| SmolJoinErr(Box::new(e)))
         })
     }
 }
 
-impl ContextExt for AsyncStdRuntime {
+impl ContextExt for SmolRuntime {
     fn scope<F, R>(locals: TaskLocals, fut: F) -> Pin<Box<dyn Future<Output = R> + Send>>
     where
         F: Future<Output = R> + Send + 'static,
@@ -105,19 +111,20 @@ impl ContextExt for AsyncStdRuntime {
     }
 }
 
-impl SpawnLocalExt for AsyncStdRuntime {
+impl SpawnLocalExt for SmolRuntime {
     fn spawn_local<F>(fut: F) -> Self::JoinHandle
     where
         F: Future<Output = ()> + 'static,
     {
-        task::spawn_local(async move {
+        let executor = async_executor::LocalExecutor::new();
+        executor.spawn(async move {
             fut.await;
             Ok(())
         })
     }
 }
 
-impl LocalContextExt for AsyncStdRuntime {
+impl LocalContextExt for SmolRuntime {
     fn scope_local<F, R>(locals: TaskLocals, fut: F) -> Pin<Box<dyn Future<Output = R>>>
     where
         F: Future<Output = R> + 'static,
@@ -136,7 +143,7 @@ pub async fn scope<F, R>(locals: TaskLocals, fut: F) -> R
 where
     F: Future<Output = R> + Send + 'static,
 {
-    AsyncStdRuntime::scope(locals, fut).await
+    SmolRuntime::scope(locals, fut).await
 }
 
 /// Set the task local event loop for the given !Send future
@@ -144,7 +151,7 @@ pub async fn scope_local<F, R>(locals: TaskLocals, fut: F) -> R
 where
     F: Future<Output = R> + 'static,
 {
-    AsyncStdRuntime::scope_local(locals, fut).await
+    SmolRuntime::scope_local(locals, fut).await
 }
 
 /// Get the current event loop from either Python or Rust async task local context
@@ -153,13 +160,13 @@ where
 /// If not, it calls [`get_running_loop`](`crate::get_running_loop`) to get the event loop
 /// associated with the current OS thread.
 pub fn get_current_loop(py: Python) -> PyResult<Bound<PyAny>> {
-    generic::get_current_loop::<AsyncStdRuntime>(py)
+    generic::get_current_loop::<SmolRuntime>(py)
 }
 
 /// Either copy the task locals from the current task OR get the current running loop and
 /// contextvars from Python.
 pub fn get_current_locals(py: Python) -> PyResult<TaskLocals> {
-    generic::get_current_locals::<AsyncStdRuntime>(py)
+    generic::get_current_locals::<SmolRuntime>(py)
 }
 
 /// Run the event loop until the given Future completes
@@ -195,7 +202,7 @@ where
     F: Future<Output = PyResult<T>> + Send + 'static,
     T: Send + Sync + 'static,
 {
-    generic::run_until_complete::<AsyncStdRuntime, _, T>(&event_loop, fut)
+    generic::run_until_complete::<SmolRuntime, _, T>(&event_loop, fut)
 }
 
 /// Run the event loop until the given Future completes
@@ -232,7 +239,7 @@ where
     F: Future<Output = PyResult<T>> + Send + 'static,
     T: Send + Sync + 'static,
 {
-    generic::run::<AsyncStdRuntime, F, T>(py, fut)
+    generic::run::<SmolRuntime, F, T>(py, fut)
 }
 
 /// Convert a Rust Future into a Python awaitable
@@ -287,7 +294,7 @@ where
     F: Future<Output = PyResult<T>> + Send + 'static,
     T: for<'py> IntoPyObject<'py> + Send + 'static,
 {
-    generic::future_into_py_with_locals::<AsyncStdRuntime, F, T>(py, locals, fut)
+    generic::future_into_py_with_locals::<SmolRuntime, F, T>(py, locals, fut)
 }
 
 /// Convert a Rust Future into a Python awaitable
@@ -333,7 +340,7 @@ where
     F: Future<Output = PyResult<T>> + Send + 'static,
     T: for<'py> IntoPyObject<'py> + Send + 'static,
 {
-    generic::future_into_py::<AsyncStdRuntime, _, T>(py, fut)
+    generic::future_into_py::<SmolRuntime, _, T>(py, fut)
 }
 
 /// Convert a `!Send` Rust Future into a Python awaitable
@@ -408,7 +415,7 @@ where
     F: Future<Output = PyResult<T>> + 'static,
     T: for<'py> IntoPyObject<'py>,
 {
-    generic::local_future_into_py_with_locals::<AsyncStdRuntime, _, T>(py, locals, fut)
+    generic::local_future_into_py_with_locals::<SmolRuntime, _, T>(py, locals, fut)
 }
 
 /// Convert a `!Send` Rust Future into a Python awaitable
@@ -474,7 +481,7 @@ where
     F: Future<Output = PyResult<T>> + 'static,
     T: for<'py> IntoPyObject<'py>,
 {
-    generic::local_future_into_py::<AsyncStdRuntime, _, T>(py, fut)
+    generic::local_future_into_py::<SmolRuntime, _, T>(py, fut)
 }
 
 /// Convert a Python `awaitable` into a Rust Future
@@ -529,7 +536,7 @@ where
 pub fn into_future(
     awaitable: Bound<PyAny>,
 ) -> PyResult<impl Future<Output = PyResult<Py<PyAny>>> + Send> {
-    generic::into_future::<AsyncStdRuntime>(awaitable)
+    generic::into_future::<SmolRuntime>(awaitable)
 }
 
 /// <span class="module-item stab portability" style="display: inline; border-radius: 3px; padding: 2px; font-size: 80%; line-height: 1.2;"><code>unstable-streams</code></span> Convert an async generator into a stream


### PR DESCRIPTION
The core idea behind this PR is add support to smol async runtime to pyo3-async-runtimes.
Right now, there's an issue on spawn tasks, which I'm investigating.
Will put it ready for review as soon as I have it fixed.
