### PR TITLE
perf: reduce `future_into_py` per-call wrapper cost by ~35%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,28 @@ To see unreleased changes, please see the CHANGELOG on the main branch.
 
 ## [Unreleased]
 
+- Reduce per-call wrapper overhead of `future_into_py` / `future_into_py_with_locals`
+  (and the `local_*` variants) by ~35% on the gather-of-N benchmark while preserving
+  cancel propagation, panic isolation, and contextvars semantics. Three independent
+  changes:
+  - Drop the `spawn_blocking`-then-`Python::attach` hop on the completion path
+    (partial revert of [#60](https://github.com/PyO3/pyo3-async-runtimes/pull/60)
+    for this specific call site; the GIL section is sub-µs so the blocking-pool
+    dispatch was costlier than the worker-block it avoided). The `Runtime`
+    trait still requires `spawn_blocking` — only the internal call site changed.
+  - Collapse the outer + inner `R::spawn` panic-isolation pattern into a single
+    `R::spawn` with `AssertUnwindSafe(...).catch_unwind()` (the same pattern
+    already used by `AsyncStdRuntime::spawn`).
+  - Simplify `TokioRuntime`'s `TASK_LOCALS` declaration from
+    `OnceCell<TaskLocals>` to `TaskLocals` directly, removing redundant cell
+    ceremony from `scope` / `scope_local`.
+- Add `benches/future_into_py.rs` (Criterion) measuring the wrapper path with
+  `single`, `gather_10`, and `gather_100` variants. Adds `criterion = "0.5"` as
+  a `dev-dependencies` only.
+- Drop the stale `if py.version_info() >= (3, 14)` early-return from the three
+  uvloop integration tests (uvloop 0.22.1 supports 3.14 end-to-end). The
+  free-threaded build guard is preserved.
+
 ## [0.28.0] - 2026-02-03
 
 - Bump to pyo3 0.28. [#76](https://github.com/PyO3/pyo3-async-runtimes/pull/76)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,13 @@ path = "pytests/test_race_condition_regression.rs"
 harness = false
 required-features = ["async-std-runtime", "testing"]
 
+
+[[bench]]
+name = "future_into_py"
+path = "benches/future_into_py.rs"
+harness = false
+required-features = ["tokio-runtime"]
+
 [dependencies]
 async-channel = { version = "2.3", optional = true }
 clap = { version = "4.5", optional = true }
@@ -131,6 +138,7 @@ pyo3 = "0.28"
 pyo3-async-runtimes-macros = { path = "pyo3-async-runtimes-macros", version = "=0.28.0", optional = true }
 
 [dev-dependencies]
+criterion = "0.5"
 pyo3 = { version = "0.28", features = ["macros"] }
 
 [dependencies.async-std]

--- a/benches/future_into_py.rs
+++ b/benches/future_into_py.rs
@@ -1,0 +1,106 @@
+//! Benchmark `future_into_py` end-to-end wrapper overhead.
+//!
+//! The user-supplied future is a no-op (`async { Ok(()) }`), so the
+//! measured wall time is dominated by the wrapper machinery —
+//! `R::spawn`, `R::scope`, panic isolation, and the completion path
+//! that calls `set_result` on the Python `asyncio.Future`. Each
+//! iteration drives the asyncio event loop until the future
+//! completes, which is the same path real users pay per call.
+//!
+//! Reference numbers on aarch64-apple-darwin, Python 3.14.3,
+//! tokio multi-thread, n=100 samples (criterion default):
+//!
+//! | bench           | main      | this branch | per-fut Δ |
+//! | --------------- | --------- | ----------- | --------- |
+//! | single_noop     |  34.2 µs  |   33.7 µs   |  -0.5 µs  |
+//! | gather_10_noop  | 239.4 µs  |  217.9 µs   |  -2.2 µs  |
+//! | gather_100_noop |   2.04 ms |    1.31 ms  |  -7.3 µs  |
+//!
+//! single_noop is dominated by `run_until_complete` event-loop
+//! overhead (~30 µs constant), so the wrapper delta is ~noise.
+//! gather_N amortises that constant over N futures, exposing the
+//! per-call wrapper cost: 20.4 → 13.1 µs/fut (-35%).
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use pyo3::prelude::*;
+use pyo3::types::PyTuple;
+use pyo3_async_runtimes::TaskLocals;
+
+fn bench_future_into_py(c: &mut Criterion) {
+    Python::initialize();
+
+    Python::attach(|py| {
+        let asyncio = py.import("asyncio").unwrap();
+        let event_loop = asyncio.call_method0("new_event_loop").unwrap();
+        asyncio
+            .call_method1("set_event_loop", (&event_loop,))
+            .unwrap();
+
+        // Build TaskLocals once with the bench event loop. The bench
+        // runs outside any running coroutine, so `get_running_loop`-
+        // based helpers (`future_into_py`, `get_current_locals`)
+        // cannot be used here; we go through the `_with_locals`
+        // entry point that the public API ultimately calls.
+        let locals = TaskLocals::new(event_loop.clone());
+
+        // Warm the tokio runtime + event loop so iteration 1 doesn't
+        // pay one-time initialisation cost.
+        let warm =
+            pyo3_async_runtimes::tokio::future_into_py_with_locals(py, locals.clone(), async {
+                Ok::<(), pyo3::PyErr>(())
+            })
+            .unwrap();
+        event_loop
+            .call_method1("run_until_complete", (warm,))
+            .unwrap();
+
+        // Single-future round-trip. Dominated by run_until_complete
+        // event-loop overhead (~25-30 µs), so the wrapper delta is
+        // small relative to noise here. Useful as a sanity ceiling.
+        c.bench_function("single_noop", |b| {
+            b.iter(|| {
+                let py_fut = pyo3_async_runtimes::tokio::future_into_py_with_locals(
+                    py,
+                    locals.clone(),
+                    async { Ok::<(), pyo3::PyErr>(()) },
+                )
+                .unwrap();
+                event_loop
+                    .call_method1("run_until_complete", (py_fut,))
+                    .unwrap();
+            });
+        });
+
+        // Gather of N noop futures. Run-loop overhead is paid once
+        // per iteration but spawn/scope/completion runs N times, so
+        // the per-future wrapper cost dominates. This is the
+        // realistic ophyd-style "asyncio.gather(*[pv.get() for pv
+        // in PVs])" workload pattern.
+        for &n in &[10usize, 100usize] {
+            let bench_name = format!("gather_{}_noop", n);
+            c.bench_function(&bench_name, |b| {
+                b.iter(|| {
+                    let mut futs: Vec<Bound<PyAny>> = Vec::with_capacity(n);
+                    for _ in 0..n {
+                        futs.push(
+                            pyo3_async_runtimes::tokio::future_into_py_with_locals(
+                                py,
+                                locals.clone(),
+                                async { Ok::<(), pyo3::PyErr>(()) },
+                            )
+                            .unwrap(),
+                        );
+                    }
+                    let args = PyTuple::new(py, futs).unwrap();
+                    let gathered = asyncio.call_method1("gather", args).unwrap();
+                    event_loop
+                        .call_method1("run_until_complete", (gathered,))
+                        .unwrap();
+                });
+            });
+        }
+    });
+}
+
+criterion_group!(benches, bench_future_into_py);
+criterion_main!(benches);

--- a/pytests/test_async_std_uvloop.rs
+++ b/pytests/test_async_std_uvloop.rs
@@ -12,11 +12,6 @@ fn main() -> pyo3::PyResult<()> {
             return Ok(());
         }
 
-        // uvloop not yet supported on 3.14
-        if py.version_info() >= (3, 14) {
-            return Ok(());
-        }
-
         let uvloop = py.import("uvloop")?;
         uvloop.call_method0("install")?;
 

--- a/pytests/test_tokio_current_thread_uvloop.rs
+++ b/pytests/test_tokio_current_thread_uvloop.rs
@@ -21,11 +21,6 @@ fn main() -> pyo3::PyResult<()> {
             return Ok(());
         }
 
-        // uvloop not yet supported on 3.14
-        if py.version_info() >= (3, 14) {
-            return Ok(());
-        }
-
         let uvloop = py.import("uvloop")?;
         uvloop.call_method0("install")?;
 

--- a/pytests/test_tokio_multi_thread_uvloop.rs
+++ b/pytests/test_tokio_multi_thread_uvloop.rs
@@ -13,11 +13,6 @@ fn main() -> pyo3::PyResult<()> {
             return Ok(());
         }
 
-        // uvloop not yet supported on 3.14
-        if py.version_info() >= (3, 14) {
-            return Ok(());
-        }
-
         let uvloop = py.import("uvloop")?;
         uvloop.call_method0("install")?;
 

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -15,6 +15,7 @@
 
 use std::{
     future::Future,
+    panic::AssertUnwindSafe,
     pin::Pin,
     sync::{Arc, Mutex},
     task::{Context, Poll},
@@ -27,6 +28,7 @@ use crate::{
 #[cfg(feature = "unstable-streams")]
 use futures_channel::mpsc;
 use futures_channel::oneshot;
+use futures_util::FutureExt;
 #[cfg(feature = "unstable-streams")]
 use futures_util::SinkExt;
 use pin_project_lite::pin_project;
@@ -625,59 +627,40 @@ where
         },),
     )?;
 
-    let future_tx1: Py<PyAny> = py_fut.clone().into();
-    let future_tx2 = future_tx1.clone_ref(py);
+    let future_tx: Py<PyAny> = py_fut.clone().into();
+    let locals_for_scope = locals.clone();
 
     R::spawn(async move {
-        let locals2 = locals.clone();
+        let result = AssertUnwindSafe(R::scope(
+            locals_for_scope,
+            Cancellable::new_with_cancel_rx(fut, cancel_rx),
+        ))
+        .catch_unwind()
+        .await;
 
-        if let Err(e) = R::spawn(async move {
-            let result = R::scope(
-                locals2.clone(),
-                Cancellable::new_with_cancel_rx(fut, cancel_rx),
-            )
-            .await;
+        let result = match result {
+            Ok(r) => r,
+            Err(panic) => Err(RustPanic::new_err(format!(
+                "rust future panicked: {}",
+                get_panic_message(&panic)
+            ))),
+        };
 
-            Python::attach(move |py| {
-                if cancelled(future_tx1.bind(py))
-                    .map_err(dump_err(py))
-                    .unwrap_or(false)
-                {
-                    return;
-                }
-
-                let _ = set_result(
-                    &locals2.event_loop(py),
-                    future_tx1.bind(py),
-                    result.and_then(|val| val.into_py_any(py)),
-                )
-                .map_err(dump_err(py));
-            });
-        })
-        .await
-        {
-            if e.is_panic() {
-                Python::attach(move |py| {
-                    if cancelled(future_tx2.bind(py))
-                        .map_err(dump_err(py))
-                        .unwrap_or(false)
-                    {
-                        return;
-                    }
-
-                    let panic_message = format!(
-                        "rust future panicked: {}",
-                        get_panic_message(&e.into_panic())
-                    );
-                    let _ = set_result(
-                        locals.0.event_loop.bind(py),
-                        future_tx2.bind(py),
-                        Err(RustPanic::new_err(panic_message)),
-                    )
-                    .map_err(dump_err(py));
-                });
+        Python::attach(move |py| {
+            if cancelled(future_tx.bind(py))
+                .map_err(dump_err(py))
+                .unwrap_or(false)
+            {
+                return;
             }
-        }
+
+            let _ = set_result(
+                locals.0.event_loop.bind(py),
+                future_tx.bind(py),
+                result.and_then(|val| val.into_py_any(py)),
+            )
+            .map_err(dump_err(py));
+        });
     });
 
     Ok(py_fut)
@@ -1038,59 +1021,40 @@ where
         },),
     )?;
 
-    let future_tx1: Py<PyAny> = py_fut.clone().into();
-    let future_tx2 = future_tx1.clone_ref(py);
+    let future_tx: Py<PyAny> = py_fut.clone().into();
+    let locals_for_scope = locals.clone();
 
     R::spawn_local(async move {
-        let locals2 = locals.clone();
+        let result = AssertUnwindSafe(R::scope_local(
+            locals_for_scope,
+            Cancellable::new_with_cancel_rx(fut, cancel_rx),
+        ))
+        .catch_unwind()
+        .await;
 
-        if let Err(e) = R::spawn_local(async move {
-            let result = R::scope_local(
-                locals2.clone(),
-                Cancellable::new_with_cancel_rx(fut, cancel_rx),
-            )
-            .await;
+        let result = match result {
+            Ok(r) => r,
+            Err(panic) => Err(RustPanic::new_err(format!(
+                "rust future panicked: {}",
+                get_panic_message(&panic)
+            ))),
+        };
 
-            Python::attach(move |py| {
-                if cancelled(future_tx1.bind(py))
-                    .map_err(dump_err(py))
-                    .unwrap_or(false)
-                {
-                    return;
-                }
-
-                let _ = set_result(
-                    locals2.0.event_loop.bind(py),
-                    future_tx1.bind(py),
-                    result.and_then(|val| val.into_py_any(py)),
-                )
-                .map_err(dump_err(py));
-            });
-        })
-        .await
-        {
-            if e.is_panic() {
-                Python::attach(move |py| {
-                    if cancelled(future_tx2.bind(py))
-                        .map_err(dump_err(py))
-                        .unwrap_or(false)
-                    {
-                        return;
-                    }
-
-                    let panic_message = format!(
-                        "rust future panicked: {}",
-                        get_panic_message(&e.into_panic())
-                    );
-                    let _ = set_result(
-                        locals.0.event_loop.bind(py),
-                        future_tx2.bind(py),
-                        Err(RustPanic::new_err(panic_message)),
-                    )
-                    .map_err(dump_err(py));
-                });
+        Python::attach(move |py| {
+            if cancelled(future_tx.bind(py))
+                .map_err(dump_err(py))
+                .unwrap_or(false)
+            {
+                return;
             }
-        }
+
+            let _ = set_result(
+                locals.0.event_loop.bind(py),
+                future_tx.bind(py),
+                result.and_then(|val| val.into_py_any(py)),
+            )
+            .map_err(dump_err(py));
+        });
     });
 
     Ok(py_fut)

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -638,49 +638,43 @@ where
             )
             .await;
 
-            // We should not hold GIL inside async-std/tokio event loop,
-            // because a blocked task may prevent other tasks from progressing.
-            R::spawn_blocking(|| {
+            Python::attach(move |py| {
+                if cancelled(future_tx1.bind(py))
+                    .map_err(dump_err(py))
+                    .unwrap_or(false)
+                {
+                    return;
+                }
+
+                let _ = set_result(
+                    &locals2.event_loop(py),
+                    future_tx1.bind(py),
+                    result.and_then(|val| val.into_py_any(py)),
+                )
+                .map_err(dump_err(py));
+            });
+        })
+        .await
+        {
+            if e.is_panic() {
                 Python::attach(move |py| {
-                    if cancelled(future_tx1.bind(py))
+                    if cancelled(future_tx2.bind(py))
                         .map_err(dump_err(py))
                         .unwrap_or(false)
                     {
                         return;
                     }
 
+                    let panic_message = format!(
+                        "rust future panicked: {}",
+                        get_panic_message(&e.into_panic())
+                    );
                     let _ = set_result(
-                        &locals2.event_loop(py),
-                        future_tx1.bind(py),
-                        result.and_then(|val| val.into_py_any(py)),
+                        locals.0.event_loop.bind(py),
+                        future_tx2.bind(py),
+                        Err(RustPanic::new_err(panic_message)),
                     )
                     .map_err(dump_err(py));
-                });
-            });
-        })
-        .await
-        {
-            if e.is_panic() {
-                R::spawn_blocking(|| {
-                    Python::attach(move |py| {
-                        if cancelled(future_tx2.bind(py))
-                            .map_err(dump_err(py))
-                            .unwrap_or(false)
-                        {
-                            return;
-                        }
-
-                        let panic_message = format!(
-                            "rust future panicked: {}",
-                            get_panic_message(&e.into_panic())
-                        );
-                        let _ = set_result(
-                            locals.0.event_loop.bind(py),
-                            future_tx2.bind(py),
-                            Err(RustPanic::new_err(panic_message)),
-                        )
-                        .map_err(dump_err(py));
-                    });
                 });
             }
         }

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -13,7 +13,6 @@
 //! features = ["unstable-streams"]
 //! ```
 
-use std::cell::OnceCell;
 use std::ops::Deref;
 use std::sync::OnceLock;
 use std::{future::Future, pin::Pin, sync::Mutex};
@@ -79,7 +78,7 @@ impl generic::JoinError for task::JoinError {
 struct TokioRuntime;
 
 tokio::task_local! {
-    static TASK_LOCALS: OnceCell<TaskLocals>;
+    static TASK_LOCALS: TaskLocals;
 }
 
 impl GenericRuntime for TokioRuntime {
@@ -108,16 +107,11 @@ impl ContextExt for TokioRuntime {
     where
         F: Future<Output = R> + Send + 'static,
     {
-        let cell = OnceCell::new();
-        cell.set(locals).unwrap();
-
-        Box::pin(TASK_LOCALS.scope(cell, fut))
+        Box::pin(TASK_LOCALS.scope(locals, fut))
     }
 
     fn get_task_locals() -> Option<TaskLocals> {
-        TASK_LOCALS
-            .try_with(|c| c.get().map(|locals| locals.clone()))
-            .unwrap_or_default()
+        TASK_LOCALS.try_with(|locals| locals.clone()).ok()
     }
 }
 
@@ -135,10 +129,7 @@ impl LocalContextExt for TokioRuntime {
     where
         F: Future<Output = R> + 'static,
     {
-        let cell = OnceCell::new();
-        cell.set(locals).unwrap();
-
-        Box::pin(TASK_LOCALS.scope(cell, fut))
+        Box::pin(TASK_LOCALS.scope(locals, fut))
     }
 }
 


### PR DESCRIPTION
Three small, independent optimisations to the default `future_into_py_with_locals` path. Per-call wrapper overhead drops from **20.4 µs → 13.1 µs (-35%)** on a gather-of-100 noop microbench, with **no change to public API and no loss of cancel propagation, panic isolation, or contextvars semantics**.

The motivating workload is EPICS PV scans — `asyncio.gather(*[pv.get() for pv in PVs])` over short Rust futures, where the wrapper itself was a meaningful share of wall time.

## Numbers

aarch64-apple-darwin, Python 3.14.3, tokio multi-thread, criterion `n=100`.

| Benchmark | main | this PR | Δ |
|---|---|---|---|
| `single_noop` | 34.2 µs | 33.7 µs | −1.7% |
| `gather_10_noop` | 239.4 µs | 217.9 µs | −8.9% |
| **`gather_100_noop`** | **2.04 ms** | **1.31 ms** | **−35.5%** |

Per-call wrapper cost: **20.4 µs → 13.1 µs (−7.3 µs)**. `single_noop` is dominated by `run_until_complete`'s constant ~30 µs, so the delta is masked there; `gather_N` amortises that constant and exposes the real per-call cost.

## What changed (3 perf commits)

1. **Drop `spawn_blocking` on the completion path** ([5d872d2](#)) — partial revert of [#60](https://github.com/PyO3/pyo3-async-runtimes/pull/60) for this one call site. The GIL section is just `cancelled() + set_result()` (sub-µs), so the blocking-pool dispatch (~5–10 µs) was costlier than the worker-block it avoided. The `Runtime::spawn_blocking` trait requirement is preserved.

2. **Single spawn + `catch_unwind` instead of nested `R::spawn`** ([12f4b08](#)) — `AssertUnwindSafe(...).catch_unwind()` gives the same panic isolation as the outer-spawn-await-JoinError pattern, with one less spawn + Box per call. `AsyncStdRuntime::spawn` already uses this pattern (`src/async_std.rs:71-72`). Side benefit: success and panic branches now share one `set_result` call site.

3. **Simplify `TokioRuntime` `TASK_LOCALS`** ([c4e6173](#)) — declare it as `TaskLocals` directly instead of `OnceCell<TaskLocals>`. The cell was always populated immediately; the wrap added nothing. Drops `use std::cell::OnceCell` and removes one pre-existing `clippy::map_clone` warning.